### PR TITLE
Rename references to descheduler-operator package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
-WORKDIR /go/src/github.com/openshift/descheduler-operator
+WORKDIR /go/src/github.com/openshift/cluster-kube-descheduler-operator
 COPY . .
-RUN go build -o descheduler-operator ./cmd/manager
+RUN go build -o cluster-kube-descheduler-operator ./cmd/manager
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
-COPY --from=builder /go/src/github.com/openshift/descheduler-operator/descheduler-operator /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/cluster-kube-descheduler-operator/cluster-kube-descheduler-operator /usr/bin/
 LABEL io.k8s.display-name="OpenShift Descheduler Operator" \
       io.k8s.description="This is a component of OpenShift and manages the descheduler" \
-      io.openshift.tags="openshift,descheduler-operator" \
+      io.openshift.tags="openshift,cluster-kube-descheduler-operator" \
       maintainer="AOS pod team, <aos-pod@redhat.com>"

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,11 +1,11 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
-WORKDIR /go/src/github.com/openshift/descheduler-operator
+WORKDIR /go/src/github.com/openshift/cluster-kube-descheduler-operator
 COPY . .
-RUN go build -o descheduler-operator ./cmd/manager
+RUN go build -o cluster-kube-descheduler-operator ./cmd/manager
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
-COPY --from=builder /go/src/github.com/openshift/descheduler-operator/descheduler-operator /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/cluster-kube-descheduler-operator/cluster-kube-descheduler-operator /usr/bin/
 LABEL io.k8s.display-name="OpenShift Descheduler Operator" \
       io.k8s.description="This is a component of OpenShift and manages the descheduler" \
-      io.openshift.tags="openshift,descheduler-operator" \
+      io.openshift.tags="openshift,cluster-kube-descheduler-operator" \
       maintainer="AOS pod team, <aos-pod@redhat.com>"

--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,16 @@
 IMAGE_REPOSITORY_NAME ?= openshift
 
 build:
-	go build -o descheduler-operator github.com/openshift/descheduler-operator/cmd/manager
+	go build -o cluster-kube-descheduler-operator github.com/openshift/cluster-kube-descheduler-operator/cmd/manager
 
 image:
-	imagebuilder -f Dockerfile -t $(IMAGE_REPOSITORY_NAME)/descheduler-operator .
+	imagebuilder -f Dockerfile -t $(IMAGE_REPOSITORY_NAME)/cluster-kube-descheduler-operator .
 
 clean:
-	rm -rf descheduler-operator 
+	rm -rf cluster-kube-descheduler-operator 
 
 test-unit:
-	go test -race -v github.com/openshift/descheduler-operator/pkg/controller/descheduler
+	go test -race -v github.com/openshift/cluster-kube-descheduler-operator/pkg/controller/descheduler
 
 verify-gofmt:
 	hack/verify-gofmt.sh

--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,13 @@
-approvers:
-  - ravisantoshgudimetla
-  - aveshagarwal
-  - sjenning
 reviewers:
   - ravisantoshgudimetla
-  - aveshagarwal
-  - sjenning
+  - sttts
+  - damemi
+  - soltysh
+  - ingvagabund
+approvers:
+  - mfojtik
+  - ravisantoshgudimetla
+  - sttts
+  - damemi
+  - soltysh
+  - ingvagabund

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# descheduler-operator
+# cluster-kube-descheduler-operator
 An operator to run descheduler on OpenShift
 
 To deploy the operator:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine:3.6
 
 USER nobody
 
-ADD build/_output/bin/descheduler-operator /usr/local/bin/descheduler-operator
+ADD build/_output/bin/cluster-kube-descheduler-operator /usr/local/bin/cluster-kube-descheduler-operator

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"runtime"
 
-	"github.com/openshift/descheduler-operator/pkg/apis"
-	"github.com/openshift/descheduler-operator/pkg/controller"
+	"github.com/openshift/cluster-kube-descheduler-operator/pkg/apis"
+	"github.com/openshift/cluster-kube-descheduler-operator/pkg/controller"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"

--- a/pkg/apis/addtoscheme_descheduler_v1alpha1.go
+++ b/pkg/apis/addtoscheme_descheduler_v1alpha1.go
@@ -1,7 +1,7 @@
 package apis
 
 import (
-	"github.com/openshift/descheduler-operator/pkg/apis/descheduler/v1alpha1"
+	"github.com/openshift/cluster-kube-descheduler-operator/pkg/apis/descheduler/v1alpha1"
 )
 
 func init() {

--- a/pkg/controller/add_descheduler.go
+++ b/pkg/controller/add_descheduler.go
@@ -1,7 +1,7 @@
 package controller
 
 import (
-	"github.com/openshift/descheduler-operator/pkg/controller/descheduler"
+	"github.com/openshift/cluster-kube-descheduler-operator/pkg/controller/descheduler"
 )
 
 func init() {

--- a/pkg/controller/descheduler/descheduler_controller.go
+++ b/pkg/controller/descheduler/descheduler_controller.go
@@ -7,10 +7,10 @@ import (
 	"reflect"
 	"strings"
 
-	deschedulerv1alpha1 "github.com/openshift/descheduler-operator/pkg/apis/descheduler/v1alpha1"
+	deschedulerv1alpha1 "github.com/openshift/cluster-kube-descheduler-operator/pkg/apis/descheduler/v1alpha1"
 	batch "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/controller/descheduler/descheduler_controller_test.go
+++ b/pkg/controller/descheduler/descheduler_controller_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	deschedulerv1alpha1 "github.com/openshift/descheduler-operator/pkg/apis/descheduler/v1alpha1"
+	deschedulerv1alpha1 "github.com/openshift/cluster-kube-descheduler-operator/pkg/apis/descheduler/v1alpha1"
 )
 
 func TestValidateStrategies(t *testing.T) {

--- a/test/e2e/descheduler_test.go
+++ b/test/e2e/descheduler_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openshift/descheduler-operator/pkg/apis"
-	operator "github.com/openshift/descheduler-operator/pkg/apis/descheduler/v1alpha1"
-	"github.com/openshift/descheduler-operator/pkg/controller/descheduler"
+	"github.com/openshift/cluster-kube-descheduler-operator/pkg/apis"
+	operator "github.com/openshift/cluster-kube-descheduler-operator/pkg/apis/descheduler/v1alpha1"
+	"github.com/openshift/cluster-kube-descheduler-operator/pkg/controller/descheduler"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
With the repo name change, CI is failing. I have a PR to update the CI here: https://github.com/openshift/release/pull/6776 and this will need to be passed through to our current build