### PR TITLE
Bug 1798220: Re-enable ability to pass additional flags to descheduler pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,11 @@ strategies:
 ```
 
 The above configmap would be mounted as a volume in descheduler pod created. Whenever we change strategies, parameters or schedule in the CR, the descheduler operator is responsible for identifying those changes and regenerating the configmap. For more information on how descheduler works, please visit [descheduler](https://docs.openshift.com/container-platform/3.11/admin_guide/scheduling/descheduler.html)
+
+
+## Parameters
+The Descheduler operator exposes the following parameters in its CRD:
+
+* `deschedulingIntervalSeconds` - this sets the number of seconds between descheduler runs
+* `image` - specifies the Descheduler container image to deploy
+* `flags` - this allows additional descheduler flags to be set, and they will be appended to the descheduler pod. Therefore, they must be in the same format as would be passed to the descheduler binary (eg, `"--dry-run"`)

--- a/manifests/0000_00_kube-descheduler-operator.crd.yaml
+++ b/manifests/0000_00_kube-descheduler-operator.crd.yaml
@@ -29,23 +29,16 @@ spec:
           description: KubeDeschedulerSpec defines the desired state of KubeDescheduler
           type: object
           properties:
-            Flags:
-              description: Flags for descheduler.
-              type: array
-              items:
-                description: Param is a key/value pair representing the parameters
-                  in strategy or flags.
-                type: object
-                properties:
-                  name:
-                    type: string
-                  value:
-                    type: string
             deschedulingIntervalSeconds:
               description: DeschedulingIntervalSeconds is the number of seconds between
                 descheduler runs
               type: integer
               format: int32
+            flags:
+              description: Flags for descheduler.
+              type: array
+              items:
+                type: string
             image:
               description: Image of the deschduler being managed. This includes the
                 version of the operand(descheduler).

--- a/pkg/apis/descheduler/v1beta1/types_descheduler.go
+++ b/pkg/apis/descheduler/v1beta1/types_descheduler.go
@@ -27,7 +27,7 @@ type KubeDeschedulerSpec struct {
 	// DeschedulingIntervalSeconds is the number of seconds between descheduler runs
 	DeschedulingIntervalSeconds *int32 `json:"deschedulingIntervalSeconds"`
 	// Flags for descheduler.
-	Flags []Param `json:"Flags"`
+	Flags []string `json:"flags"`
 	// Image of the deschduler being managed. This includes the version of the operand(descheduler).
 	Image string `json:"image, omitempty"`
 }

--- a/pkg/apis/descheduler/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/descheduler/v1beta1/zz_generated.deepcopy.go
@@ -96,9 +96,14 @@ func (in *KubeDeschedulerSpec) DeepCopyInto(out *KubeDeschedulerSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.DeschedulingIntervalSeconds != nil {
+		in, out := &in.DeschedulingIntervalSeconds, &out.DeschedulingIntervalSeconds
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Flags != nil {
 		in, out := &in.Flags, &out.Flags
-		*out = make([]Param, len(*in))
+		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
 	return


### PR DESCRIPTION
https://github.com/openshift/cluster-kube-descheduler-operator/pull/66 accidentally removed the ability to pass additional descheduler flags to the pod (see options here: https://github.com/kubernetes-sigs/descheduler/blob/30d05382b6e6fc40c8ecc38aedd23918d8eed849/cmd/descheduler/app/options/options.go#L51-L60).

This also replaces the parsing/validating code with just a string list of flags, which are immediately passed to the descheduler pod. Any invalid flags will raise an error when the descheduler runs anyway, so I don't think we need to be responsible for validating them.