### PR TITLE
Bug 1798497: Update deployment generation statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,18 @@ oc create -f manifests/.
 
 Replace `oc` with `kubectl` in case you want descheduler to run with kubernetes. All the required components are created in `openshift-descheduler-operator` namespace.
 
+## Descheduler strategies
+
+The Descheduler operator attempts to simplify the descheduler strategy names from their [upstream names](https://github.com/kubernetes-sigs/descheduler/#policy-and-strategies). Thus when set on the operator, these strategy names map to:
+
+| Operator param | Descheduler strategy |
+| ---- | ---- |
+| `duplicates` | `RemoveDuplicates` |
+| `interpodantiaffinity` | `RemovePodsViolatingInterPodAntiAffinity` |
+| `lownodeutilization` | `LowNodeUtilization` |
+| `nodeaffinity` | `RemovePodsViolatingNodeAffinity` |
+| `nodetaints` | `RemovePodsViolatingNodeTaints` |
+
 ## Sample CR
 
 A sample CR definition looks like below (the operator expects `config` CR under `openshift-kube-descheduler-operator` namespace):

--- a/manifests/0000_00_kube-descheduler-operator.crd.yaml
+++ b/manifests/0000_00_kube-descheduler-operator.crd.yaml
@@ -6,8 +6,12 @@ spec:
   group: operator.openshift.io
   names:
     kind: KubeDescheduler
+    listKind: KubeDeschedulerList
     plural: kubedeschedulers
-  scope: ""
+    singular: kubedescheduler
+  scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: KubeDescheduler is the Schema for the deschedulers API
@@ -163,13 +167,3 @@ spec:
               description: version is the level this availability applies to
               type: string
   version: v1beta1
-  versions:
-  - name: v1beta1
-    served: true
-    storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/manifests/02_kube-descheduler-operator.cr.yaml
+++ b/manifests/02_kube-descheduler-operator.cr.yaml
@@ -6,3 +6,4 @@ metadata:
 spec:
   image: gcr.io/k8s-staging-descheduler/descheduler:0.9.0-79-gd845040d7
   deschedulingIntervalSeconds: 3600
+

--- a/pkg/apis/descheduler/v1beta1/types_descheduler.go
+++ b/pkg/apis/descheduler/v1beta1/types_descheduler.go
@@ -14,8 +14,8 @@ type KubeDescheduler struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   KubeDeschedulerSpec   `json:"spec,omitempty"`
-	Status KubeDeschedulerStatus `json:"status,omitempty"`
+	Spec   KubeDeschedulerSpec   `json:"spec"`
+	Status KubeDeschedulerStatus `json:"status"`
 }
 
 // KubeDeschedulerSpec defines the desired state of KubeDescheduler

--- a/pkg/operator/operatorclient/interfaces.go
+++ b/pkg/operator/operatorclient/interfaces.go
@@ -1,3 +1,61 @@
 package operatorclient
 
+import (
+	operatorv1 "github.com/openshift/api/operator/v1"
+	operatorconfigclientv1beta1 "github.com/openshift/cluster-kube-descheduler-operator/pkg/generated/clientset/versioned/typed/descheduler/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
 const OperatorNamespace = "openshift-kube-descheduler-operator"
+
+type DeschedulerClient struct {
+	SharedInformer cache.SharedIndexInformer
+	OperatorClient operatorconfigclientv1beta1.KubedeschedulersV1beta1Interface
+}
+
+func (c *DeschedulerClient) Informer() cache.SharedIndexInformer {
+	return c.SharedInformer
+}
+
+func (c *DeschedulerClient) GetOperatorState() (spec *operatorv1.OperatorSpec, status *operatorv1.OperatorStatus, resourceVersion string, err error) {
+	instance, err := c.OperatorClient.KubeDeschedulers(OperatorNamespace).Get("cluster", metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, "", err
+	}
+	return &instance.Spec.OperatorSpec, &instance.Status.OperatorStatus, instance.ResourceVersion, nil
+}
+
+func (c *DeschedulerClient) UpdateOperatorSpec(resourceVersion string, spec *operatorv1.OperatorSpec) (out *operatorv1.OperatorSpec, newResourceVersion string, err error) {
+	original, err := c.OperatorClient.KubeDeschedulers(OperatorNamespace).Get("cluster", metav1.GetOptions{})
+	if err != nil {
+		return nil, "", err
+	}
+	copy := original.DeepCopy()
+	copy.ResourceVersion = resourceVersion
+	copy.Spec.OperatorSpec = *spec
+
+	ret, err := c.OperatorClient.KubeDeschedulers(OperatorNamespace).Update(copy)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return &ret.Spec.OperatorSpec, ret.ResourceVersion, nil
+}
+
+func (c *DeschedulerClient) UpdateOperatorStatus(resourceVersion string, status *operatorv1.OperatorStatus) (out *operatorv1.OperatorStatus, err error) {
+	original, err := c.OperatorClient.KubeDeschedulers(OperatorNamespace).Get("cluster", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	copy := original.DeepCopy()
+	copy.ResourceVersion = resourceVersion
+	copy.Status.OperatorStatus = *status
+
+	ret, err := c.OperatorClient.KubeDeschedulers(OperatorNamespace).UpdateStatus(copy)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ret.Status.OperatorStatus, nil
+}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -34,9 +34,15 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 	}
 	operatorConfigInformers := operatorclientinformers.NewSharedInformerFactory(operatorConfigClient, 10*time.Minute)
 
+	deschedulerClient := &operatorclient.DeschedulerClient{
+		SharedInformer: operatorConfigInformers.Kubedeschedulers().V1beta1().KubeDeschedulers().Informer(),
+		OperatorClient: operatorConfigClient.KubedeschedulersV1beta1(),
+	}
+
 	targetConfigReconciler := NewTargetConfigReconciler(
 		operatorConfigClient.KubedeschedulersV1beta1(),
 		operatorConfigInformers.Kubedeschedulers().V1beta1().KubeDeschedulers(),
+		deschedulerClient,
 		kubeClient,
 		cc.EventRecorder,
 	)


### PR DESCRIPTION
#66 merged without actually checking any valid value against the expected generation of the deployment. This implements the necessary interfaces to use library-go helpers to update the operator status with the generation information, and uses the information to check against when updating the deployment.