### PR TITLE
bug 1803139: Add appregistry delivery label to Dockerfile.rhel7

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -8,4 +8,5 @@ COPY --from=builder /go/src/github.com/openshift/cluster-kube-descheduler-operat
 LABEL io.k8s.display-name="OpenShift Descheduler Operator" \
       io.k8s.description="This is a component of OpenShift and manages the descheduler" \
       io.openshift.tags="openshift,cluster-kube-descheduler-operator" \
+      com.redhat.delivery.appregistry=true \
       maintainer="AOS pod team, <aos-pod@redhat.com>"


### PR DESCRIPTION
ART relies on the presence of `com.redhat.delivery.appregistry` label to identify it as an OLM operator.