### PR TITLE
[release-4.4] bug 1805794: Doozer requires spec.tags[].name to be dist-git names

### DIFF
--- a/manifests/4.4/image-references
+++ b/manifests/4.4/image-references
@@ -3,11 +3,11 @@ kind: ImageStream
 apiVersion: image.openshift.io/v1
 spec:
   tags:
-  - name: descheduler-operator
+  - name: cluster-kube-descheduler-operator
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-cluster-kube-descheduler-operator:4.4
-  - name: descheduler
+  - name: atomic-openshift-descheduler
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-descheduler:4.4


### PR DESCRIPTION
Cherry-picking https://github.com/openshift/cluster-kube-descheduler-operator/pull/85 by hand so we don't need to wait for the next 2 hours for #85 to get merged.