### PR TITLE
image-references: descheduler is the right name for the image

### DIFF
--- a/manifests/4.4/image-references
+++ b/manifests/4.4/image-references
@@ -7,7 +7,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-cluster-kube-descheduler-operator:4.4
-  - name: atomic-openshift-descheduler
+  - name: descheduler
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-descheduler:4.4


### PR DESCRIPTION
Since https://github.com/openshift/ocp-build-data/blob/openshift-4.4/images/atomic-openshift-descheduler.yml#L26
changes the name from atomic-openshift-descheduler to just descheduler.