### PR TITLE
[release-4.4] bug 1805794: Descheduler image back to descheduler 4.4

### DIFF
--- a/manifests/4.4/image-references
+++ b/manifests/4.4/image-references
@@ -7,7 +7,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-cluster-kube-descheduler-operator:4.4
-  - name: atomic-openshift-descheduler
+  - name: descheduler
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-descheduler:4.4


### PR DESCRIPTION
Backporting https://github.com/openshift/cluster-kube-descheduler-operator/pull/88

Since https://github.com/openshift/ocp-build-data/blob/openshift-4.4/images/atomic-openshift-descheduler.yml#L26
changes the name from atomic-openshift-descheduler to just descheduler.