### PR TITLE
[release-4.4] bug 1805794: Set the CSV category to OpenShift Optional

### DIFF
--- a/manifests/4.4/cluster-kube-descheduler-operator.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/4.4/cluster-kube-descheduler-operator.v4.4.0.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     repository: https://github.com/openshift/cluster-kube-descheduler-operator
     support: Red Hat, Inc.
     capabilities: Basic Install
-    categories: Scheduling
+    categories: OpenShift Optional
 spec:
   customresourcedefinitions:
     owned:


### PR DESCRIPTION
Based on https://github.com/operator-framework/operator-courier/blob/master/operatorcourier/validate.py#L580 the following categories are valid:
- "AI/Machine Learning",
- "Application Runtime",
- "Big Data",
- "Cloud Provider",
- "Developer Tools",
- "Database",
- "Integration & Delivery",
- "Logging & Tracing",
- "Monitoring",
- "Networking",
- "OpenShift Optional",
- "Security",
- "Storage",
- "Streaming & Messaging"

"OpenShift Optional" is the closest valid category for the descheduler.

Cherry pick of https://github.com/openshift/cluster-kube-descheduler-operator/pull/90