### PR TITLE
Add support for actual descheduler strategy names in operator config

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,6 @@ oc create -f manifests/.
 
 Replace `oc` with `kubectl` in case you want descheduler to run with kubernetes. All the required components are created in `openshift-descheduler-operator` namespace.
 
-## Descheduler strategies
-
-The Descheduler operator attempts to simplify the descheduler strategy names from their [upstream names](https://github.com/kubernetes-sigs/descheduler/#policy-and-strategies). Thus when set on the operator, these strategy names map to:
-
-| Operator param | Descheduler strategy |
-| ---- | ---- |
-| `duplicates` | `RemoveDuplicates` |
-| `interpodantiaffinity` | `RemovePodsViolatingInterPodAntiAffinity` |
-| `lownodeutilization` | `LowNodeUtilization` |
-| `nodeaffinity` | `RemovePodsViolatingNodeAffinity` |
-| `nodetaints` | `RemovePodsViolatingNodeTaints` |
-
 ## Sample CR
 
 A sample CR definition looks like below (the operator expects `config` CR under `openshift-kube-descheduler-operator` namespace):
@@ -34,7 +22,7 @@ metadata:
 spec:
   deschedulingIntervalSeconds: 1800
   strategies:
-    - name: "lownodeutilization"
+    - name: "LowNodeUtilization"
       params:
        - name: "cputhreshold"
          value: "10"
@@ -50,9 +38,11 @@ spec:
          value: "60"
        - name: "nodes"
          value: "3"
-    - name: "duplicates"
+    - name: "RemoveDuplicates"
 ```
-The valid list of strategies are "lownodeutilization", "duplicates", "interpodantiaffinity", "nodeaffinity", and "nodetaints". Out of the above only lownodeutilization has parameters like cputhreshold, memorythreshold etc. Using the above strategies defined in CR we create a configmap in openshift-descheduler-operator namespace. As of now, adding new strategies could be done through code. DeschedulingIntervalSeconds field contains the number of seconds between a descheduler run (0 in this field will only run the descheduler once and exit). Nodes field indicate on how many nodes the lownodeutilization strategy should run.
+The valid list of strategies are `RemoveDuplicates`, `LowNodeUtilization`, `RemovePodsViolatingInterPodAntiAffinity`, `RemovePodsViolatingNodeAffinity`, and `RemovePodsViolatingNodeTaints`. These strategies are documented in detail in the [descheduler README](https://github.com/kubernetes-sigs/descheduler/#policy-and-strategies).
+
+Using the above strategies defined in CR we create a configmap in openshift-descheduler-operator namespace. As shown in the above example CR, the `LowNodeUtilization` strategy is the only one which accepts additional `params`, which map to the `thresholds` and `targetThresholds` parameters as defined in the [`LowNodeUtilization` section of the descheduler README](https://github.com/kubernetes-sigs/descheduler/#lownodeutilization). The `nodes` parameter corresponds to `numberOfNodes`, which activates this strategy only when the number of underutilized nodes is above the configured value (default `0`).
 
 ## How does the descheduler operator work?
 

--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -150,9 +150,9 @@ func generateConfigMapString(requestedStrategies []deschedulerv1beta1.Strategy) 
 	// There is no need to do validation here. By the time, we reach here, validation would have already happened.
 	for _, strategy := range requestedStrategies {
 		switch strings.ToLower(strategy.Name) {
-		case "duplicates":
+		case "duplicates", "removeduplicates":
 			policy.Strategies["RemoveDuplicates"] = deschedulerapi.DeschedulerStrategy{Enabled: true}
-		case "interpodantiaffinity":
+		case "interpodantiaffinity", "removepodsviolatinginterpodantiaffinity":
 			policy.Strategies["RemovePodsViolatingInterPodAntiAffinity"] = deschedulerapi.DeschedulerStrategy{Enabled: true}
 		case "lownodeutilization":
 			utilizationThresholds := deschedulerapi.NodeResourceUtilizationThresholds{NumberOfNodes: 0}
@@ -176,7 +176,7 @@ func generateConfigMapString(requestedStrategies []deschedulerv1beta1.Strategy) 
 					targetThresholds[v1.ResourceMemory] = deschedulerapi.Percentage(value)
 				case "podstargetthreshold":
 					targetThresholds[v1.ResourcePods] = deschedulerapi.Percentage(value)
-				case "nodes":
+				case "nodes", "numberOfNodes":
 					utilizationThresholds.NumberOfNodes = value
 				}
 			}
@@ -191,13 +191,13 @@ func generateConfigMapString(requestedStrategies []deschedulerv1beta1.Strategy) 
 					NodeResourceUtilizationThresholds: utilizationThresholds,
 				},
 			}
-		case "nodeaffinity":
+		case "nodeaffinity", "removepodsviolatingnodeaffinity":
 			policy.Strategies["RemovePodsViolatingNodeAffinity"] = deschedulerapi.DeschedulerStrategy{Enabled: true,
 				Params: deschedulerapi.StrategyParameters{
 					NodeAffinityType: []string{"requiredDuringSchedulingIgnoredDuringExecution"},
 				},
 			}
-		case "nodetaints":
+		case "nodetaints", "removepodsviolatingnodetaints":
 			policy.Strategies["RemovePodsViolatingNodeTaints"] = deschedulerapi.DeschedulerStrategy{Enabled: true}
 		default:
 			klog.Warningf("not using unknown strategy '%s'", strategy.Name)


### PR DESCRIPTION
Fixes https://github.com/openshift/cluster-kube-descheduler-operator/issues/83

This will add support to enable descheduler strategies by their actual documented upstream names, which should alleviate confusion and necessary documentation