### PR TITLE
Revert changes to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@ RUN rm manifests/4*/image-references
 RUN go build -o cluster-kube-descheduler-operator ./cmd/cluster-kube-descheduler-operator
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
-COPY --from=builder cluster-kube-descheduler-operator /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/cluster-kube-descheduler-operator/cluster-kube-descheduler-operator /usr/bin/
 # Upstream bundle and index images does not support versioning so
 # we need to copy a specific version under /manifests layout directly
-COPY --from=builder manifests/4.4/* /manifests
-COPY --from=builder metadata /metadata
+COPY --from=builder /go/src/github.com/openshift/cluster-kube-descheduler-operator/manifests/4.4/* /manifests/
+COPY --from=builder /go/src/github.com/openshift/cluster-kube-descheduler-operator/metadata /metadata
 
 LABEL io.k8s.display-name="OpenShift Descheduler Operator" \
       io.k8s.description="This is a component of OpenShift and manages the descheduler" \


### PR DESCRIPTION
These changes fail to build in Docker with the following error: 
```
Sending build context to Docker daemon  99.73MB
Step 1/10 : FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
golang-1.13: Pulling from openshift/release
ab5ef0e58194: Pull complete 
301c90ab1c95: Pull complete 
Digest: sha256:b78a902936aabab4407529efcd1ca492956efe36de31dc1e16e53bb4b699111f
Status: Downloaded newer image for registry.svc.ci.openshift.org/openshift/release:golang-1.13
 ---> 3d233cfdbcdc
Step 2/10 : WORKDIR /go/src/github.com/openshift/cluster-kube-descheduler-operator
 ---> Running in 20283a17dd62
Removing intermediate container 20283a17dd62
 ---> ea70021478fe
Step 3/10 : COPY . .
 ---> aef454209edd
Step 4/10 : RUN rm manifests/4*/image-references
 ---> Running in 8887c0bed92b
Removing intermediate container 8887c0bed92b
 ---> 0abb809d86f9
Step 5/10 : RUN go build -o cluster-kube-descheduler-operator ./cmd/cluster-kube-descheduler-operator
 ---> Running in 945c9d9634ea
Removing intermediate container 945c9d9634ea
 ---> 856c28b4e90d
Step 6/10 : FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
base: Pulling from openshift/origin-v4.0
c2340472a0fa: Pull complete 
6e55351c18ff: Pull complete 
b2d2704dda6c: Pull complete 
a2c10be042b9: Pull complete 
Digest: sha256:cbd0e2931e6ae8cbd1522cd7226cff89629c21a3652f6fd57d84f405d432c07a
Status: Downloaded newer image for registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 ---> f779ab8af41a
Step 7/10 : COPY --from=builder cluster-kube-descheduler-operator /usr/bin/
COPY failed: stat /var/lib/docker/overlay2/d1898d44633d071ea858eb875f9315c668faf374fd75d0dc5b7afa59e90349fc/merged/cluster-kube-descheduler-operator: no such file or directory
```
But reverting the changes in https://github.com/openshift/cluster-kube-descheduler-operator/pull/94/files fixes it. @ingvagabund can you please take a look?