### PR TITLE
Re-add manual deployment manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ Run the descheduler in your OpenShift cluster to move pods based on specific str
 
 ## Deploy the operator
 
+### Quick Development
+
+1. Build and push the operator image to a registry:
+2. Ensure the `image` spec in `deploy/05_deployment.yaml` refers to the operator image you pushed
+3. Run `oc create -f deploy/.`
+
+### OperatorHub install with custom index image
+
+This process refers to building the operator in a way that it can be installed locally via the OperatorHub with a custom index image
+
 1. build and push the image to a registry (e.g. https://quay.io):
    ```sh
    $ podman build -t quay.io/<username>/ose-cluster-kube-descheduler-operator-bundle:latest -f Dockerfile .

--- a/deploy/0000_00_kube-descheduler-operator.crd.yaml
+++ b/deploy/0000_00_kube-descheduler-operator.crd.yaml
@@ -1,0 +1,169 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubedeschedulers.operator.openshift.io
+spec:
+  group: operator.openshift.io
+  names:
+    kind: KubeDescheduler
+    listKind: KubeDeschedulerList
+    plural: kubedeschedulers
+    singular: kubedescheduler
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: KubeDescheduler is the Schema for the deschedulers API
+      type: object
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: KubeDeschedulerSpec defines the desired state of KubeDescheduler
+          type: object
+          properties:
+            deschedulingIntervalSeconds:
+              description: DeschedulingIntervalSeconds is the number of seconds between
+                descheduler runs
+              type: integer
+              format: int32
+            flags:
+              description: Flags for descheduler.
+              type: array
+              items:
+                type: string
+            image:
+              description: Image of the deschduler being managed. This includes the
+                version of the operand(descheduler).
+              type: string
+            logLevel:
+              description: logLevel is an intent based logging for an overall component.  It
+                does not give fine grained control, but it is a simple way to manage
+                coarse grained logging choices that operators have to interpret for
+                their operands.
+              type: string
+            managementState:
+              description: managementState indicates whether and how the operator
+                should manage the component
+              type: string
+              pattern: ^(Managed|Unmanaged|Force|Removed)$
+            observedConfig:
+              description: observedConfig holds a sparse config that controller has
+                observed from the cluster state.  It exists in spec because it is
+                an input to the level for the operator
+              type: object
+              nullable: true
+              x-kubernetes-preserve-unknown-fields: true
+            operatorLogLevel:
+              description: operatorLogLevel is an intent based logging for the operator
+                itself.  It does not give fine grained control, but it is a simple
+                way to manage coarse grained logging choices that operators have to
+                interpret for themselves.
+              type: string
+            strategies:
+              description: Strategies contain list of strategies that should be enabled
+                in descheduler.
+              type: array
+              items:
+                description: Strategy supported by descheduler
+                type: object
+                properties:
+                  name:
+                    type: string
+                  params:
+                    type: array
+                    items:
+                      description: Param is a key/value pair representing the parameters
+                        in strategy or flags.
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+            unsupportedConfigOverrides:
+              description: 'unsupportedConfigOverrides holds a sparse config that
+                will override any previously set options.  It only needs to be the
+                fields to override it will end up overlaying in the following order:
+                1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides'
+              type: object
+              nullable: true
+              x-kubernetes-preserve-unknown-fields: true
+        status:
+          description: KubeDeschedulerStatus defines the observed state of KubeDescheduler
+          type: object
+          properties:
+            conditions:
+              description: conditions is a list of conditions and their status
+              type: array
+              items:
+                description: OperatorCondition is just the standard condition fields.
+                type: object
+                properties:
+                  lastTransitionTime:
+                    type: string
+                    format: date-time
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+            generations:
+              description: generations are used to determine when an item needs to
+                be reconciled or has changed in a way that needs a reaction.
+              type: array
+              items:
+                description: GenerationStatus keeps track of the generation for a
+                  given resource so that decisions about forced updates can be made.
+                type: object
+                properties:
+                  group:
+                    description: group is the group of the thing you're tracking
+                    type: string
+                  hash:
+                    description: hash is an optional field set for resources without
+                      generation that are content sensitive like secrets and configmaps
+                    type: string
+                  lastGeneration:
+                    description: lastGeneration is the last generation of the workload
+                      controller involved
+                    type: integer
+                    format: int64
+                  name:
+                    description: name is the name of the thing you're tracking
+                    type: string
+                  namespace:
+                    description: namespace is where the thing you're tracking is
+                    type: string
+                  resource:
+                    description: resource is the resource type of the thing you're
+                      tracking
+                    type: string
+            observedGeneration:
+              description: observedGeneration is the last generation change you've
+                dealt with
+              type: integer
+              format: int64
+            readyReplicas:
+              description: readyReplicas indicates how many replicas are ready and
+                at the desired state
+              type: integer
+              format: int32
+            version:
+              description: version is the level this availability applies to
+              type: string
+  version: v1beta1

--- a/deploy/01_namespace.yaml
+++ b/deploy/01_namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-kube-descheduler-operator
+

--- a/deploy/02_clusterrole.yaml
+++ b/deploy/02_clusterrole.yaml
@@ -1,0 +1,41 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: descheduler-operator
+rules:
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - kubedeschedulers.operator.openshift.io
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - pods
+  - configmaps
+  - secrets
+  - names
+  - nodes
+  - pods/eviction
+  - events
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - replicasets
+  verbs:
+  - "*"
+- apiGroups: ["batch", "extensions"]
+  resources: ["jobs", "cronjobs"]
+  verbs:
+  - "*"

--- a/deploy/02_kube-descheduler-operator.cr.yaml
+++ b/deploy/02_kube-descheduler-operator.cr.yaml
@@ -1,0 +1,8 @@
+apiVersion: operator.openshift.io/v1beta1
+kind: KubeDescheduler
+metadata:
+  name: cluster
+  namespace: openshift-kube-descheduler-operator
+spec:
+  image: gcr.io/k8s-staging-descheduler/descheduler:0.9.0-79-gd845040d7
+  deschedulingIntervalSeconds: 3600

--- a/deploy/03_clusterrolebinding.yaml
+++ b/deploy/03_clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: descheduler-role-binding 
+subjects:
+- kind: ServiceAccount
+  name: openshift-descheduler
+  namespace: openshift-kube-descheduler-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: descheduler-operator

--- a/deploy/04_serviceaccount.yaml
+++ b/deploy/04_serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openshift-descheduler
+  namespace: openshift-kube-descheduler-operator

--- a/deploy/05_deployment.yaml
+++ b/deploy/05_deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: descheduler-operator
+  namespace: openshift-kube-descheduler-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: descheduler-operator
+  template:
+    metadata:
+      labels:
+        name: descheduler-operator
+    spec:
+      containers:
+        - name: descheduler-operator
+          image: docker.io/mdame/descheduler-operator
+          ports:
+          - containerPort: 60000
+            name: metrics
+          command:
+          - cluster-kube-descheduler-operator
+          args:
+          - "operator"
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPERATOR_NAME
+              value: "descheduler-operator"
+      serviceAccountName: openshift-descheduler
+      serviceAccount: openshift-descheduler

--- a/deploy/05_kube-system-rolebinding.yaml
+++ b/deploy/05_kube-system-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openshift-kube-descheduler-operator
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: openshift-descheduler
+  namespace: openshift-kube-descheduler-operator


### PR DESCRIPTION
These manifests provide a way for developers to quickly iterate on a simple deployment of the operator without needing to deploy a custom index image to install via operatorhub. Having them as a quick deployment option enables faster development with custom images.