### PR TITLE
Provide manifests for deploying the operator without OLM (for development only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ Run the descheduler in your OpenShift cluster to move pods based on specific str
 
 ## Deploy the operator
 
+### Quick Development
+
+1. Build and push the operator image to a registry:
+2. Ensure the `image` spec in `deploy/05_deployment.yaml` refers to the operator image you pushed
+3. Run `oc create -f deploy/.`
+
+### OperatorHub install with custom index image
+
+This process refers to building the operator in a way that it can be installed locally via the OperatorHub with a custom index image
+
 1. build and push the image to a registry (e.g. https://quay.io):
    ```sh
    $ podman build -t quay.io/<username>/ose-cluster-kube-descheduler-operator-bundle:latest -f Dockerfile .

--- a/deploy/0000_00_kube-descheduler-operator.crd.yaml
+++ b/deploy/0000_00_kube-descheduler-operator.crd.yaml
@@ -1,0 +1,1 @@
+../manifests/4.4/kube-descheduler-operator.crd.yaml

--- a/deploy/01_namespace.yaml
+++ b/deploy/01_namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-kube-descheduler-operator

--- a/deploy/02_clusterrole.yaml
+++ b/deploy/02_clusterrole.yaml
@@ -1,0 +1,41 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: descheduler-operator
+rules:
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - kubedeschedulers.operator.openshift.io
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - pods
+  - configmaps
+  - secrets
+  - names
+  - nodes
+  - pods/eviction
+  - events
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - replicasets
+  verbs:
+  - "*"
+- apiGroups: ["batch", "extensions"]
+  resources: ["jobs", "cronjobs"]
+  verbs:
+  - "*"

--- a/deploy/02_kube-descheduler-operator.cr.yaml
+++ b/deploy/02_kube-descheduler-operator.cr.yaml
@@ -1,0 +1,26 @@
+apiVersion: operator.openshift.io/v1beta1
+kind: KubeDescheduler
+metadata:
+  name: cluster
+  namespace: openshift-kube-descheduler-operator
+spec:
+  image: quay.io/openshift/origin-descheduler:latest
+  deschedulingIntervalSeconds: 3600
+  strategies:
+  - name: "LowNodeUtilization"
+    params:
+     - name: "cputhreshold"
+       value: "10"
+     - name: "memorythreshold"
+       value: "20"
+     - name: "podsthreshold"
+       value: "30"
+     - name: "memorytargetthreshold"
+       value: "40"
+     - name: "cputargetthreshold"
+       value: "50"
+     - name: "podstargetthreshold"
+       value: "60"
+     - name: "nodes"
+       value: "3"
+  - name: "RemoveDuplicates"

--- a/deploy/03_clusterrolebinding.yaml
+++ b/deploy/03_clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: descheduler-role-binding 
+subjects:
+- kind: ServiceAccount
+  name: openshift-descheduler
+  namespace: openshift-kube-descheduler-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: descheduler-operator
+

--- a/deploy/04_serviceaccount.yaml
+++ b/deploy/04_serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openshift-descheduler
+  namespace: openshift-kube-descheduler-operator

--- a/deploy/05_deployment.yaml
+++ b/deploy/05_deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: descheduler-operator
+  namespace: openshift-kube-descheduler-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: descheduler-operator
+  template:
+    metadata:
+      labels:
+        name: descheduler-operator
+    spec:
+      containers:
+        - name: descheduler-operator
+          image: quay.io/openshift/origin-cluster-kube-descheduler-operator:latest
+          ports:
+          - containerPort: 60000
+            name: metrics
+          command:
+          - cluster-kube-descheduler-operator
+          args:
+          - "operator"
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPERATOR_NAME
+              value: "descheduler-operator"
+      serviceAccountName: openshift-descheduler
+      serviceAccount: openshift-descheduler

--- a/deploy/05_kube-system-rolebinding.yaml
+++ b/deploy/05_kube-system-rolebinding.yaml
@@ -1,0 +1,1 @@
+../manifests/4.4/kube-system-rolebinding.yaml


### PR DESCRIPTION
Until we are able to generate all the manifests from the bundle.