### PR TITLE
bug 1827169: Bump master to version 4.5

### DIFF
--- a/manifests/4.5/cluster-kube-descheduler-operator.v4.5.0.clusterserviceversion.yaml
+++ b/manifests/4.5/cluster-kube-descheduler-operator.v4.5.0.clusterserviceversion.yaml
@@ -1,0 +1,166 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  # The version value is substituted by the ART pipeline
+  name: clusterkubedescheduleroperator.v4.5.0
+  namespace: openshift-kube-descheduler-operator
+  annotations:
+    alm-examples: |
+      [
+        {
+          "apiVersion": "operator.openshift.io/v1beta1",
+          "kind": "KubeDescheduler",
+          "metadata": {
+            "name": "cluster",
+            "namespace": "openshift-kube-descheduler-operator"
+          },
+          "spec": {
+            "image": "quay.io/openshift/origin-descheduler:4.5",
+            "deschedulingIntervalSeconds": 3600
+          }
+        }
+      ]
+    certified: "false"
+    containerImage: quay.io/openshift/origin-cluster-kube-descheduler-operator:4.5
+    createdAt: 2020/04/18
+    olm.skipRange: ">=4.3.0-0 <4.5.0"
+    description: An operator to run descheduler in Openshift cluster.
+    repository: https://github.com/openshift/cluster-kube-descheduler-operator
+    support: Red Hat, Inc.
+    capabilities: Basic Install
+    categories: OpenShift Optional
+spec:
+  customresourcedefinitions:
+    owned:
+    - displayName: Kube Descheduler
+      description: KubeDescheduler is the Schema for the deschedulers API
+      group: operator.openshift.io
+      kind: KubeDescheduler
+      name: kubedeschedulers.operator.openshift.io
+      version: v1beta1
+  description: |
+      The Kube Descheduler Operator provides the ability to evict a running pod so that the pod can be rescheduled onto a more suitable node.
+
+      There are several situations where descheduling can benefit your cluster:
+
+      * Nodes are underutilized or overutilized.
+      * Pod and node affinity requirements, such as taints or labels, have changed and the original scheduling decisions are no longer appropriate for certain nodes.
+      * Node failure requires pods to be moved.
+      * New nodes are added to clusters.
+
+      ## Descheduler Strategies
+
+      Once the operator is installed, you can configure one or more strategies to identify pods to evict. The scheduler will schedule the replacement of the evicted pods.
+
+      The following strategies are supported:
+
+      * `LowNodeUtilization` - This strategy finds nodes that are underutilized and evicts pods, if possible, from other nodes in the hope that recreation of evicted pods will be scheduled on these underutilized nodes.
+      * `RemoveDuplicates` - This strategy ensures that there is only one pod associated with a ReplicaSet, ReplicationController, Deployment, or Job running on same node. If there are more, then those duplicate pods are evicted for better spreading of pods in a cluster.
+      * `RemovePodsViolatingInterPodAntiAffinity` - This strategy ensures that pods violating inter-pod anti-affinity are removed from nodes.
+      * `RemovePodsViolatingNodeAffinity` - This strategy ensures that pods violating node affinity are removed from nodes.
+      * `RemovePodsViolatingNodeTaints` - This strategy ensures that pods violating `NoSchedule` taints on nodes are removed.
+
+      These strategies are documented in detail in the [descheduler README](https://github.com/kubernetes-sigs/descheduler/#policy-and-strategies).
+
+      ## Additional Parameters
+
+      In addition to the strategies, the following parameters can be configured:
+
+      * `deschedulingIntervalSeconds` - Set the number of seconds between descheduler runs. A value of `0` in this field runs the descheduler once and exits.
+      * `image` - Set the descheduler container image to deploy.
+      * `flags` - Set one or more flags to append to the descheduler Pod. This flag must be in the format ready to pass to the binary, such as `"--dry-run"`.
+  displayName: Kube Descheduler Operator
+  keywords: ["scheduling", "descheduler", "workload"]
+  provider:
+    name: Red Hat, Inc.
+  maturity: beta
+  version: 4.5.0
+  links:
+  - name: Source Code
+    url: https://github.com/openshift/cluster-kube-descheduler-operator
+  maintainers:
+  - email: support@redhat.com
+    name: Red Hat
+  minKubeVersion: 1.17.0
+  labels:
+    olm-owner-enterprise-app: cluster-kube-descheduler-operator
+    olm-status-descriptors: cluster-kube-descheduler-operator.v4.5.0
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  install:
+    spec:
+      clusterPermissions:
+      - serviceAccountName: openshift-descheduler
+        rules:
+        - apiGroups:
+          - operator.openshift.io
+          resources:
+          - "*"
+          verbs:
+          - "*"
+        - apiGroups:
+          - kubedeschedulers.operator.openshift.io
+          resources:
+          - "*"
+          verbs:
+          - "*"
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          - pods
+          - configmaps
+          - secrets
+          - names
+          - nodes
+          - pods/eviction
+          - events
+          verbs:
+          - "*"
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - "*"
+      deployments:
+      - name: descheduler-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: descheduler-operator
+          template:
+            metadata:
+              labels:
+                name: descheduler-operator
+            spec:
+              containers:
+                - name: descheduler-operator
+                  image: quay.io/openshift/origin-cluster-kube-descheduler-operator:4.5
+                  ports:
+                  - containerPort: 60000
+                    name: metrics
+                  command:
+                  - cluster-kube-descheduler-operator
+                  args:
+                  - "operator"
+                  imagePullPolicy: Always
+                  env:
+                    - name: WATCH_NAMESPACE
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.namespace
+                    - name: OPERATOR_NAME
+                      value: "descheduler-operator"
+              serviceAccountName: openshift-descheduler
+              serviceAccount: openshift-descheduler
+    strategy: deployment

--- a/manifests/4.5/image-references
+++ b/manifests/4.5/image-references
@@ -1,0 +1,13 @@
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+spec:
+  tags:
+  - name: cluster-kube-descheduler-operator
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-cluster-kube-descheduler-operator:4.5
+  - name: descheduler
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-descheduler:4.5

--- a/manifests/4.5/kube-descheduler-operator.crd.yaml
+++ b/manifests/4.5/kube-descheduler-operator.crd.yaml
@@ -1,0 +1,169 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubedeschedulers.operator.openshift.io
+spec:
+  group: operator.openshift.io
+  names:
+    kind: KubeDescheduler
+    listKind: KubeDeschedulerList
+    plural: kubedeschedulers
+    singular: kubedescheduler
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: KubeDescheduler is the Schema for the deschedulers API
+      type: object
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: KubeDeschedulerSpec defines the desired state of KubeDescheduler
+          type: object
+          properties:
+            deschedulingIntervalSeconds:
+              description: DeschedulingIntervalSeconds is the number of seconds between
+                descheduler runs
+              type: integer
+              format: int32
+            flags:
+              description: Flags for descheduler.
+              type: array
+              items:
+                type: string
+            image:
+              description: Image of the deschduler being managed. This includes the
+                version of the operand(descheduler).
+              type: string
+            logLevel:
+              description: logLevel is an intent based logging for an overall component.  It
+                does not give fine grained control, but it is a simple way to manage
+                coarse grained logging choices that operators have to interpret for
+                their operands.
+              type: string
+            managementState:
+              description: managementState indicates whether and how the operator
+                should manage the component
+              type: string
+              pattern: ^(Managed|Unmanaged|Force|Removed)$
+            observedConfig:
+              description: observedConfig holds a sparse config that controller has
+                observed from the cluster state.  It exists in spec because it is
+                an input to the level for the operator
+              type: object
+              nullable: true
+              x-kubernetes-preserve-unknown-fields: true
+            operatorLogLevel:
+              description: operatorLogLevel is an intent based logging for the operator
+                itself.  It does not give fine grained control, but it is a simple
+                way to manage coarse grained logging choices that operators have to
+                interpret for themselves.
+              type: string
+            strategies:
+              description: Strategies contain list of strategies that should be enabled
+                in descheduler.
+              type: array
+              items:
+                description: Strategy supported by descheduler
+                type: object
+                properties:
+                  name:
+                    type: string
+                  params:
+                    type: array
+                    items:
+                      description: Param is a key/value pair representing the parameters
+                        in strategy or flags.
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+            unsupportedConfigOverrides:
+              description: 'unsupportedConfigOverrides holds a sparse config that
+                will override any previously set options.  It only needs to be the
+                fields to override it will end up overlaying in the following order:
+                1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides'
+              type: object
+              nullable: true
+              x-kubernetes-preserve-unknown-fields: true
+        status:
+          description: KubeDeschedulerStatus defines the observed state of KubeDescheduler
+          type: object
+          properties:
+            conditions:
+              description: conditions is a list of conditions and their status
+              type: array
+              items:
+                description: OperatorCondition is just the standard condition fields.
+                type: object
+                properties:
+                  lastTransitionTime:
+                    type: string
+                    format: date-time
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+            generations:
+              description: generations are used to determine when an item needs to
+                be reconciled or has changed in a way that needs a reaction.
+              type: array
+              items:
+                description: GenerationStatus keeps track of the generation for a
+                  given resource so that decisions about forced updates can be made.
+                type: object
+                properties:
+                  group:
+                    description: group is the group of the thing you're tracking
+                    type: string
+                  hash:
+                    description: hash is an optional field set for resources without
+                      generation that are content sensitive like secrets and configmaps
+                    type: string
+                  lastGeneration:
+                    description: lastGeneration is the last generation of the workload
+                      controller involved
+                    type: integer
+                    format: int64
+                  name:
+                    description: name is the name of the thing you're tracking
+                    type: string
+                  namespace:
+                    description: namespace is where the thing you're tracking is
+                    type: string
+                  resource:
+                    description: resource is the resource type of the thing you're
+                      tracking
+                    type: string
+            observedGeneration:
+              description: observedGeneration is the last generation change you've
+                dealt with
+              type: integer
+              format: int64
+            readyReplicas:
+              description: readyReplicas indicates how many replicas are ready and
+                at the desired state
+              type: integer
+              format: int32
+            version:
+              description: version is the level this availability applies to
+              type: string
+  version: v1beta1

--- a/manifests/4.5/kube-system-rolebinding.yaml
+++ b/manifests/4.5/kube-system-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openshift-kube-descheduler-operator
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: openshift-descheduler
+  namespace: openshift-kube-descheduler-operator

--- a/manifests/cluster-kube-descheduler-operator.package.yaml
+++ b/manifests/cluster-kube-descheduler-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: cluster-kube-descheduler-operator
 channels:
-- name: "4.4"
-  currentCSV: cluster-kube-descheduler-operator.v4.4.0
+- name: "4.5"
+  currentCSV: cluster-kube-descheduler-operator.v4.5.0

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.0.1"
+	Version = "4.5.0"
 )


### PR DESCRIPTION
Based on:
```
Error Reported
--------------
ose-cluster-kube-descheduler-operator: file does not exist: /mnt/XXX/ose-cluster-kube-descheduler-operator/manifests/4.5/image-references
```

Mimicking changes in https://github.com/openshift/sriov-network-operator/pull/154
- bumping package version to 4.5
- cloning 4.4 manifests into 4.5