### PR TITLE
Lower case LowNodeUtilization thresholds

### DIFF
--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -173,7 +173,7 @@ func generateConfigMapString(requestedStrategies []deschedulerv1beta1.Strategy) 
 				if err != nil {
 					return "", err
 				}
-				switch param.Name {
+				switch strings.ToLower(param.Name) {
 				case "cputhreshold":
 					thresholds[v1.ResourceCPU] = deschedulerapi.Percentage(value)
 				case "memorythreshold":


### PR DESCRIPTION
Master branch allows to specify threshold in UpperCase style.
Allow the same in 4.4 branch to clear confusion.