### PR TITLE
bug 1879139: Be more verbose when the operator configuration is missing

### DIFF
--- a/pkg/operator/operatorclient/interfaces.go
+++ b/pkg/operator/operatorclient/interfaces.go
@@ -11,6 +11,7 @@ import (
 )
 
 const OperatorNamespace = "openshift-kube-descheduler-operator"
+const OperatorConfigName = "cluster"
 
 type DeschedulerClient struct {
 	Ctx            context.Context
@@ -23,7 +24,7 @@ func (c *DeschedulerClient) Informer() cache.SharedIndexInformer {
 }
 
 func (c *DeschedulerClient) GetOperatorState() (spec *operatorv1.OperatorSpec, status *operatorv1.OperatorStatus, resourceVersion string, err error) {
-	instance, err := c.OperatorClient.KubeDeschedulers(OperatorNamespace).Get(c.Ctx, "cluster", metav1.GetOptions{})
+	instance, err := c.OperatorClient.KubeDeschedulers(OperatorNamespace).Get(c.Ctx, OperatorConfigName, metav1.GetOptions{})
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -31,7 +32,7 @@ func (c *DeschedulerClient) GetOperatorState() (spec *operatorv1.OperatorSpec, s
 }
 
 func (c *DeschedulerClient) UpdateOperatorSpec(resourceVersion string, spec *operatorv1.OperatorSpec) (out *operatorv1.OperatorSpec, newResourceVersion string, err error) {
-	original, err := c.OperatorClient.KubeDeschedulers(OperatorNamespace).Get(c.Ctx, "cluster", metav1.GetOptions{})
+	original, err := c.OperatorClient.KubeDeschedulers(OperatorNamespace).Get(c.Ctx, OperatorConfigName, metav1.GetOptions{})
 	if err != nil {
 		return nil, "", err
 	}
@@ -48,7 +49,7 @@ func (c *DeschedulerClient) UpdateOperatorSpec(resourceVersion string, spec *ope
 }
 
 func (c *DeschedulerClient) UpdateOperatorStatus(resourceVersion string, status *operatorv1.OperatorStatus) (out *operatorv1.OperatorStatus, err error) {
-	original, err := c.OperatorClient.KubeDeschedulers(OperatorNamespace).Get(c.Ctx, "cluster", metav1.GetOptions{})
+	original, err := c.OperatorClient.KubeDeschedulers(OperatorNamespace).Get(c.Ctx, OperatorConfigName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +66,7 @@ func (c *DeschedulerClient) UpdateOperatorStatus(resourceVersion string, status 
 }
 
 func (c *DeschedulerClient) GetObjectMeta() (meta *metav1.ObjectMeta, err error) {
-	instance, err := c.OperatorClient.KubeDeschedulers(OperatorNamespace).Get(c.Ctx, "cluster", metav1.GetOptions{})
+	instance, err := c.OperatorClient.KubeDeschedulers(OperatorNamespace).Get(c.Ctx, OperatorConfigName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -89,8 +89,9 @@ func NewTargetConfigReconciler(
 }
 
 func (c TargetConfigReconciler) sync() error {
-	descheduler, err := c.operatorClient.KubeDeschedulers(operatorclient.OperatorNamespace).Get(c.ctx, "cluster", metav1.GetOptions{})
+	descheduler, err := c.operatorClient.KubeDeschedulers(operatorclient.OperatorNamespace).Get(c.ctx, operatorclient.OperatorConfigName, metav1.GetOptions{})
 	if err != nil {
+		klog.ErrorS(err, "unable to get operator configuration", "namespace", operatorclient.OperatorNamespace, "kubedescheduler", operatorclient.OperatorConfigName)
 		return err
 	}
 


### PR DESCRIPTION
When the operator configuration is deployed in different namespace than `openshift-kube-descheduler-operator`,
the operator is reporting:

```
E0825 23:53:11.641464       1 target_config_reconciler.go:307] key failed with : kubedeschedulers.operator.openshift.io "cluster" not found
```

The log does not say anything about the namespace.
Explicitly mentioning the expected namespace may give user more hints on what's wrong.