### PR TITLE
Bug 1879975: Move priorityclasses to correct apiGroup in SA

### DIFF
--- a/manifests/4.6/cluster-kube-descheduler-operator.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/4.6/cluster-kube-descheduler-operator.v4.6.0.clusterserviceversion.yaml
@@ -125,9 +125,16 @@ spec:
           - nodes
           - pods/eviction
           - events
-          - priorityclasses
           verbs:
           - "*"
+        - apiGroups:
+          - scheduling.k8s.io
+          resources:
+          - priorityclasses
+          verbs:
+          - get
+          - watch
+          - list
         - apiGroups:
           - apps
           resources:


### PR DESCRIPTION
With permissions taken from upstream: https://github.com/kubernetes-sigs/descheduler/blob/release-1.19/kubernetes/rbac.yaml#L20-L22