### PR TITLE
bug 1881869: LowNodeUtilization: don't Atoi thresholdPriority params as other params

### DIFF
--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -176,6 +176,14 @@ func generateNamespaces(params []deschedulerv1beta1.Param) *deschedulerapi.Names
 	return &namespaces
 }
 
+func isPriorityThresholdParam(param deschedulerv1beta1.Param) bool {
+	switch strings.ToLower(param.Name) {
+	case "thresholdpriority", "thresholdpriorityclassname":
+		return true
+	}
+	return false
+}
+
 func generatePriorityThreshold(params []deschedulerv1beta1.Param) (string, *int32, error) {
 	var thresholdPriority *int32
 	var thresholdPriorityClassName string
@@ -245,6 +253,9 @@ func generateConfigMapString(requestedStrategies []deschedulerv1beta1.Strategy) 
 			thresholds := deschedulerapi.ResourceThresholds{}
 			targetThresholds := deschedulerapi.ResourceThresholds{}
 			for _, param := range strategy.Params {
+				if isPriorityThresholdParam(param) {
+					continue
+				}
 				value, err := strconv.Atoi(param.Value)
 				if err != nil {
 					return "", err

--- a/pkg/operator/target_config_reconciler_test.go
+++ b/pkg/operator/target_config_reconciler_test.go
@@ -1,9 +1,10 @@
 package operator
 
 import (
-	deschedulerv1beta1 "github.com/openshift/cluster-kube-descheduler-operator/pkg/apis/descheduler/v1beta1"
 	"strings"
 	"testing"
+
+	deschedulerv1beta1 "github.com/openshift/cluster-kube-descheduler-operator/pkg/apis/descheduler/v1beta1"
 )
 
 func TestValidateStrategies(t *testing.T) {
@@ -44,5 +45,39 @@ func TestValidateStrategies(t *testing.T) {
 				t.Errorf("expected error %+v, got %+v", test.expectedErr, err)
 			}
 		})
+	}
+}
+
+func TestGenerateConfigMapString(t *testing.T) {
+	tests := []struct {
+		requestedStrategies []deschedulerv1beta1.Strategy
+		expectedErr         string
+	}{
+		{
+			requestedStrategies: []deschedulerv1beta1.Strategy{
+				{
+					Name: "LowNodeUtilization",
+					Params: []deschedulerv1beta1.Param{
+						{
+							Name:  "thresholdPriorityClassName",
+							Value: "priorityclass1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		_, err := generateConfigMapString(test.requestedStrategies)
+		switch {
+		case err == nil && len(test.expectedErr) == 0:
+		case err == nil && len(test.expectedErr) != 0:
+			t.Errorf("expected error %+v, got none", test.expectedErr)
+		case err != nil && len(test.expectedErr) == 0:
+			t.Errorf("unexpected error %+v", err)
+		case err != nil && len(test.expectedErr) != 0 && !strings.Contains(err.Error(), test.expectedErr):
+			t.Errorf("expected error %+v, got %+v", test.expectedErr, err)
+		}
 	}
 }


### PR DESCRIPTION
Before the fix:

```
E0923 05:32:54.844907       1 target_config_reconciler.go:467] key failed with : strconv.Atoi: parsing "priorityclass1": invalid syntax
```