### PR TITLE
bug 1887740: Extend olm.skipRange check to properly compare pre-release versions

### DIFF
--- a/manifests/4.4/cluster-kube-descheduler-operator.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/4.4/cluster-kube-descheduler-operator.v4.4.0.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     certified: "false"
     containerImage: quay.io/openshift/origin-cluster-kube-descheduler-operator:4.4
     createdAt: 2020/02/21
-    olm.skipRange: ">=4.3.0-0 <4.4.0"
+    olm.skipRange: ">=4.3.0-0 < 4.4.0-0"
     description: An operator to run descheduler in Openshift cluster.
     repository: https://github.com/openshift/cluster-kube-descheduler-operator
     support: Red Hat, Inc.

--- a/manifests/4.5/cluster-kube-descheduler-operator.v4.5.0.clusterserviceversion.yaml
+++ b/manifests/4.5/cluster-kube-descheduler-operator.v4.5.0.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     certified: "false"
     containerImage: quay.io/openshift/origin-cluster-kube-descheduler-operator:4.5
     createdAt: 2020/04/18
-    olm.skipRange: ">=4.3.0-0 <4.5.0"
+    olm.skipRange: ">=4.3.0-0 < 4.5.0-0"
     description: An operator to run descheduler in Openshift cluster.
     repository: https://github.com/openshift/cluster-kube-descheduler-operator
     support: Red Hat, Inc.

--- a/manifests/4.6/cluster-kube-descheduler-operator.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/4.6/cluster-kube-descheduler-operator.v4.6.0.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     certified: "false"
     containerImage: quay.io/openshift/origin-cluster-kube-descheduler-operator:4.6
     createdAt: 2020/04/18
-    olm.skipRange: ">=4.3.0-0 <4.6.0"
+    olm.skipRange: ">=4.3.0-0 < 4.6.0-0"
     description: An operator to run descheduler in Openshift cluster.
     repository: https://github.com/openshift/cluster-kube-descheduler-operator
     support: Red Hat, Inc.

--- a/manifests/4.7/cluster-kube-descheduler-operator.v4.7.0.clusterserviceversion.yaml
+++ b/manifests/4.7/cluster-kube-descheduler-operator.v4.7.0.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     certified: "false"
     containerImage: quay.io/openshift/origin-cluster-kube-descheduler-operator:4.7
     createdAt: 2020/04/18
-    olm.skipRange: ">=4.3.0-0 <4.7.0"
+    olm.skipRange: ">=4.3.0-0 < 4.7.0-0"
     description: An operator to run descheduler in Openshift cluster.
     repository: https://github.com/openshift/cluster-kube-descheduler-operator
     support: Red Hat, Inc.


### PR DESCRIPTION
When major, minor, and patch are equal, a pre-release version has lower precedence than a normal version so 4.6.0-202010061132.p0 < 4.6.0.
Because of this, the solver is confused by this and adds the this version into `replaces` field so we end up with the situation that this version is replacing itself.
As a result, the CSV is stuck in Pending state.