### PR TITLE
bug 1903188: Set --logging-format to text, empty value generates an error message

### DIFF
--- a/bindata/v4.1.0/kube-descheduler/deployment.yaml
+++ b/bindata/v4.1.0/kube-descheduler/deployment.yaml
@@ -35,6 +35,7 @@ spec:
           args:
             - --policy-config-file=/policy-dir/policy.yaml
             - --v=2
+            - --logging-format=text
           volumeMounts:
             - mountPath: "/policy-dir"
               name: "policy-volume"

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -119,6 +119,7 @@ spec:
           args:
             - --policy-config-file=/policy-dir/policy.yaml
             - --v=2
+            - --logging-format=text
           volumeMounts:
             - mountPath: "/policy-dir"
               name: "policy-volume"


### PR DESCRIPTION
"failed to validate server configuration" err="unsupported log format: "