### PR TITLE
Bug 1943224: Update olmSkipRange in 4.7 and 4.8 to remove dev pattern

### DIFF
--- a/manifests/4.7/cluster-kube-descheduler-operator.v4.7.0.clusterserviceversion.yaml
+++ b/manifests/4.7/cluster-kube-descheduler-operator.v4.7.0.clusterserviceversion.yaml
@@ -24,7 +24,7 @@ metadata:
     certified: "false"
     containerImage: quay.io/openshift/origin-cluster-kube-descheduler-operator:4.7
     createdAt: 2020/04/18
-    olm.skipRange: ">=4.3.0-0 < 4.7.0"
+    olm.skipRange: ">=4.5.0 < 4.7.0"
     description: An operator to run descheduler in Openshift cluster.
     repository: https://github.com/openshift/cluster-kube-descheduler-operator
     support: Red Hat, Inc.

--- a/manifests/4.8/cluster-kube-descheduler-operator.v4.8.0.clusterserviceversion.yaml
+++ b/manifests/4.8/cluster-kube-descheduler-operator.v4.8.0.clusterserviceversion.yaml
@@ -24,7 +24,7 @@ metadata:
     certified: "false"
     containerImage: quay.io/openshift/origin-cluster-kube-descheduler-operator:4.8
     createdAt: 2020/04/18
-    olm.skipRange: ">=4.6.0-0 < 4.8.0"
+    olm.skipRange: ">=4.6.0 < 4.8.0"
     description: An operator to run descheduler in Openshift cluster.
     repository: https://github.com/openshift/cluster-kube-descheduler-operator
     support: Red Hat, Inc.


### PR DESCRIPTION
Follow up to https://github.com/openshift/cluster-kube-descheduler-operator/pull/177, this removes the dev pattern from the lower version numbers in the CSVs