### PR TITLE
bug 1948640: CRD: add missing subresources.status so the CRD's status can be updated

### DIFF
--- a/manifests/4.8/kube-descheduler-operator.crd.yaml
+++ b/manifests/4.8/kube-descheduler-operator.crd.yaml
@@ -10,6 +10,8 @@ spec:
     plural: kubedeschedulers
     singular: kubedescheduler
   scope: Namespaced
+  subresources:
+    status: {}
   versions:
   - name: v1
     schema:

--- a/pkg/apis/descheduler/v1/types_descheduler.go
+++ b/pkg/apis/descheduler/v1/types_descheduler.go
@@ -11,6 +11,7 @@ import (
 // +k8s:openapi-gen=true
 // +genclient
 // +kubebuilder:storageversion
+// +kubebuilder:subresource:status
 type KubeDescheduler struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/descheduler/v1beta1/types_descheduler.go
+++ b/pkg/apis/descheduler/v1beta1/types_descheduler.go
@@ -10,6 +10,7 @@ import (
 // KubeDescheduler is the Schema for the deschedulers API
 // +k8s:openapi-gen=true
 // +genclient
+// +kubebuilder:subresource:status
 type KubeDescheduler struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
To allow CRD's status to be updated