### PR TITLE
bug 1949972: servicemonitor: replace exported_namespace with pod_namespace

### DIFF
--- a/bindata/v4.1.0/kube-descheduler/servicemonitor.yaml
+++ b/bindata/v4.1.0/kube-descheduler/servicemonitor.yaml
@@ -11,6 +11,11 @@ spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     interval: 30s
+    metricRelabelings:
+    - action: replace
+      sourceLabels:
+      - exported_namespace
+      targetLabel: pod_namespace
     path: /metrics
     port: https
     scheme: https

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -275,6 +275,11 @@ spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     interval: 30s
+    metricRelabelings:
+    - action: replace
+      sourceLabels:
+      - exported_namespace
+      targetLabel: pod_namespace
     path: /metrics
     port: https
     scheme: https


### PR DESCRIPTION
The namespace label is reserved label (see
https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#alertmanagerendpoints).
So the namespace label (indicating from which namespace a pod got
evicted) is automatically relabeled into exported_namespace.
To avoid confusion of what the label means, relabel it into
pod_namespace.

Metrics entry before:
```
descheduler_pods_evicted{endpoint="https", exported_namespace="test1", instance="10.129.3.136:10258", job="metrics", namespace="openshift-kube-descheduler-operator", pod="cluster-85df694595-blktt", result="success", service="metrics", strategy="RemoveDuplicatePods"}
```

Metrics entry after:
```
descheduler_pods_evicted{endpoint="https", exported_namespace="test1", instance="10.129.3.136:10258", job="metrics", namespace="openshift-kube-descheduler-operator", pod="cluster-85df694595-blktt", pod_namespace="test1", result="success", service="metrics", strategy="RemoveDuplicatePods"}
```