### PR TITLE
Bug 1955595: Add DevPreviewLongLifecycle profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ The following profiles are currently provided:
 * [`AffinityAndTaints`](#AffinityAndTaints)
 * [`TopologyAndDuplicates`](#TopologyAndDuplicates)
 * [`LifecycleAndUtilization`](#LifecycleAndUtilization)
+  
+Along with the following profiles, which are in development and may change:
+* [`DevPreviewLongLifecycle`](#DevPreviewLongLifecycle)
 
 Each of these enables cluster-wide descheduling (excluding openshift and kube-system namespaces) based on certain goals.
 
@@ -100,6 +103,10 @@ This profile enables the [`LowNodeUtilizaition`](https://github.com/kubernetes-s
 [`RemovePodsHavingTooManyRestarts`](https://github.com/kubernetes-sigs/descheduler/#removepodshavingtoomanyrestarts) and 
 [`PodLifeTime`](https://github.com/kubernetes-sigs/descheduler/#podlifetime) strategies. In the future, more configuration
 may be made available through the operator for these strategies based on user feedback.
+
+### DevPreviewLongLifecycle
+This profile provides cluster resource balancing similar to [LifecycleAndUtilization](#LifecycleAndUtilization) for longer-running 
+clusters. It does not evict pods based on the 24 hour lifetime used by LifecycleAndUtilization.
 
 ## How does the descheduler operator work?
 

--- a/bindata/v4.1.0/profiles/DevPreviewLongLifecycle.yaml
+++ b/bindata/v4.1.0/profiles/DevPreviewLongLifecycle.yaml
@@ -1,0 +1,21 @@
+apiVersion: "descheduler/v1alpha1"
+kind: "DeschedulerPolicy"
+strategies:
+  "RemovePodsHavingTooManyRestarts":
+     enabled: true
+     params:
+       podsHavingTooManyRestarts:
+         podRestartThreshold: 100
+         includingInitContainers: true
+  "LowNodeUtilization":
+     enabled: true
+     params:
+       nodeResourceUtilizationThresholds:
+         thresholds:
+           "cpu" : 20
+           "memory": 20
+           "pods": 20
+         targetThresholds:
+           "cpu" : 50
+           "memory": 50
+           "pods": 50

--- a/manifests/4.8/kube-descheduler-operator.crd.yaml
+++ b/manifests/4.8/kube-descheduler-operator.crd.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -10,8 +12,6 @@ spec:
     plural: kubedeschedulers
     singular: kubedescheduler
   scope: Namespaced
-  subresources:
-    status: {}
   versions:
   - name: v1
     schema:
@@ -70,6 +70,7 @@ spec:
                   - AffinityAndTaints
                   - TopologyAndDuplicates
                   - LifecycleAndUtilization
+                  - DevPreviewLongLifecycle
                   type: string
                 type: array
               unsupportedConfigOverrides:
@@ -140,6 +141,8 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
   - name: v1beta1
     schema:
       openAPIV3Schema:
@@ -294,6 +297,8 @@ spec:
         type: object
     served: true
     storage: false
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/pkg/apis/descheduler/v1/types_descheduler.go
+++ b/pkg/apis/descheduler/v1/types_descheduler.go
@@ -38,7 +38,7 @@ type KubeDeschedulerSpec struct {
 
 // DeschedulerProfile allows configuring the enabled strategy profiles for the descheduler
 // it allows multiple profiles to be enabled at once, which will have cumulative effects on the cluster.
-// +kubebuilder:validation:Enum=AffinityAndTaints;TopologyAndDuplicates;LifecycleAndUtilization
+// +kubebuilder:validation:Enum=AffinityAndTaints;TopologyAndDuplicates;LifecycleAndUtilization;DevPreviewLongLifecycle
 type DeschedulerProfile string
 
 var (
@@ -52,6 +52,9 @@ var (
 
 	// LifecycleAndUtilization attempts to balance pods based on node resource usage, pod age, and pod restarts
 	LifecycleAndUtilization DeschedulerProfile = "LifecycleAndUtilization"
+
+	// DevPreviewLongLifecycle handles cluster lifecycle over a long term
+	DevPreviewLongLifecycle DeschedulerProfile = "DevPreviewLongLifecycle"
 )
 
 // KubeDeschedulerStatus defines the observed state of KubeDescheduler

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -7,6 +7,7 @@
 // bindata/v4.1.0/kube-descheduler/service.yaml
 // bindata/v4.1.0/kube-descheduler/servicemonitor.yaml
 // bindata/v4.1.0/profiles/AffinityAndTaints.yaml
+// bindata/v4.1.0/profiles/DevPreviewLongLifecycle.yaml
 // bindata/v4.1.0/profiles/LifecycleAndUtilization.yaml
 // bindata/v4.1.0/profiles/TopologyAndDuplicates.yaml
 package v410_00_assets
@@ -338,6 +339,44 @@ func v410ProfilesAffinityandtaintsYaml() (*asset, error) {
 	return a, nil
 }
 
+var _v410ProfilesDevpreviewlonglifecycleYaml = []byte(`apiVersion: "descheduler/v1alpha1"
+kind: "DeschedulerPolicy"
+strategies:
+  "RemovePodsHavingTooManyRestarts":
+     enabled: true
+     params:
+       podsHavingTooManyRestarts:
+         podRestartThreshold: 100
+         includingInitContainers: true
+  "LowNodeUtilization":
+     enabled: true
+     params:
+       nodeResourceUtilizationThresholds:
+         thresholds:
+           "cpu" : 20
+           "memory": 20
+           "pods": 20
+         targetThresholds:
+           "cpu" : 50
+           "memory": 50
+           "pods": 50
+`)
+
+func v410ProfilesDevpreviewlonglifecycleYamlBytes() ([]byte, error) {
+	return _v410ProfilesDevpreviewlonglifecycleYaml, nil
+}
+
+func v410ProfilesDevpreviewlonglifecycleYaml() (*asset, error) {
+	bytes, err := v410ProfilesDevpreviewlonglifecycleYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v4.1.0/profiles/DevPreviewLongLifecycle.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _v410ProfilesLifecycleandutilizationYaml = []byte(`apiVersion: "descheduler/v1alpha1"
 kind: "DeschedulerPolicy"
 strategies:
@@ -464,6 +503,7 @@ var _bindata = map[string]func() (*asset, error){
 	"v4.1.0/kube-descheduler/service.yaml":         v410KubeDeschedulerServiceYaml,
 	"v4.1.0/kube-descheduler/servicemonitor.yaml":  v410KubeDeschedulerServicemonitorYaml,
 	"v4.1.0/profiles/AffinityAndTaints.yaml":       v410ProfilesAffinityandtaintsYaml,
+	"v4.1.0/profiles/DevPreviewLongLifecycle.yaml": v410ProfilesDevpreviewlonglifecycleYaml,
 	"v4.1.0/profiles/LifecycleAndUtilization.yaml": v410ProfilesLifecycleandutilizationYaml,
 	"v4.1.0/profiles/TopologyAndDuplicates.yaml":   v410ProfilesTopologyandduplicatesYaml,
 }
@@ -520,6 +560,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		}},
 		"profiles": {nil, map[string]*bintree{
 			"AffinityAndTaints.yaml":       {v410ProfilesAffinityandtaintsYaml, map[string]*bintree{}},
+			"DevPreviewLongLifecycle.yaml": {v410ProfilesDevpreviewlonglifecycleYaml, map[string]*bintree{}},
 			"LifecycleAndUtilization.yaml": {v410ProfilesLifecycleandutilizationYaml, map[string]*bintree{}},
 			"TopologyAndDuplicates.yaml":   {v410ProfilesTopologyandduplicatesYaml, map[string]*bintree{}},
 		}},


### PR DESCRIPTION
Re: https://issues.redhat.com/browse/WRKLDS-286
This adds a new Beta profile `BetaLongLifecycle` which is similar to `LifecycleAndUtilization` but which does not evict running pods that exceed the latter's 24-hour lifetime limit.