### PR TITLE
Bug 1959177: Update dev clusterrole manifest

### DIFF
--- a/deploy/02_clusterrole.yaml
+++ b/deploy/02_clusterrole.yaml
@@ -10,6 +10,12 @@ rules:
   verbs:
   - "*"
 - apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - "*"
+- apiGroups:
   - kubedeschedulers.operator.openshift.io
   resources:
   - "*"
@@ -28,6 +34,13 @@ rules:
   - events
   verbs:
   - "*"
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - '*'
 - apiGroups:
   - scheduling.k8s.io
   resources:


### PR DESCRIPTION
Updating to copy the changes from https://github.com/openshift/cluster-kube-descheduler-operator/commit/1a022bab559d982c238aee17d78bf555dd9bcc55#