### PR TITLE
Bug 1989724: Add Profiles to evict localStorage pods/ignore PVC pods

### DIFF
--- a/bindata/assets/profiles/DoNotEvictPodsWithPVC.yaml
+++ b/bindata/assets/profiles/DoNotEvictPodsWithPVC.yaml
@@ -1,0 +1,3 @@
+apiVersion: "descheduler/v1alpha1"
+kind: "DeschedulerPolicy"
+ignorePvcPods: true

--- a/bindata/assets/profiles/EvictPodsWithLocalStorage.yaml
+++ b/bindata/assets/profiles/EvictPodsWithLocalStorage.yaml
@@ -1,0 +1,3 @@
+apiVersion: "descheduler/v1alpha1"
+kind: "DeschedulerPolicy"
+evictLocalStoragePods: true

--- a/manifests/4.9/kube-descheduler-operator.crd.yaml
+++ b/manifests/4.9/kube-descheduler-operator.crd.yaml
@@ -82,6 +82,8 @@ spec:
                       - LifecycleAndUtilization
                       - DevPreviewLongLifecycle
                       - SoftTopologyAndDuplicates
+                      - EvictPodsWithLocalStorage
+                      - DoNotEvictPodsWithPVC
                 unsupportedConfigOverrides:
                   description: 'unsupportedConfigOverrides holds a sparse config that will override any previously set options.  It only needs to be the fields to override it will end up overlaying in the following order: 1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides'
                   type: object

--- a/pkg/apis/descheduler/v1/types_descheduler.go
+++ b/pkg/apis/descheduler/v1/types_descheduler.go
@@ -50,7 +50,7 @@ type ProfileCustomizations struct {
 
 // DeschedulerProfile allows configuring the enabled strategy profiles for the descheduler
 // it allows multiple profiles to be enabled at once, which will have cumulative effects on the cluster.
-// +kubebuilder:validation:Enum=AffinityAndTaints;TopologyAndDuplicates;LifecycleAndUtilization;DevPreviewLongLifecycle;SoftTopologyAndDuplicates
+// +kubebuilder:validation:Enum=AffinityAndTaints;TopologyAndDuplicates;LifecycleAndUtilization;DevPreviewLongLifecycle;SoftTopologyAndDuplicates;EvictPodsWithLocalStorage;DoNotEvictPodsWithPVC
 type DeschedulerProfile string
 
 var (
@@ -68,6 +68,12 @@ var (
 
 	// LifecycleAndUtilization attempts to balance pods based on node resource usage, pod age, and pod restarts
 	LifecycleAndUtilization DeschedulerProfile = "LifecycleAndUtilization"
+
+	// EvictPodsWithLocalStorage enables pods with local storage to be evicted by the descheduler by all other profiles
+	EvictPodsWithLocalStorage DeschedulerProfile = "EvictPodsWithLocalStorage"
+
+	// DoNotEvictPodsWithPVC prevents pods with PVCs from being evicted by all other profiles
+	DoNotEvictPodsWithPVC DeschedulerProfile = "DoNotEvictPodsWithPVC"
 
 	// DevPreviewLongLifecycle handles cluster lifecycle over a long term
 	DevPreviewLongLifecycle DeschedulerProfile = "DevPreviewLongLifecycle"


### PR DESCRIPTION
Adds profiles which will enable these options in the descheduler policy
ref: https://issues.redhat.com/browse/WRKLDS-304