### PR TITLE
Bug 1990603: Fix unable to find scheduler config

### DIFF
--- a/deploy/0000_00_kube-descheduler-operator.crd.yaml
+++ b/deploy/0000_00_kube-descheduler-operator.crd.yaml
@@ -1,1 +1,1 @@
-../manifests/4.8/kube-descheduler-operator.crd.yaml
+../manifests/4.9/kube-descheduler-operator.crd.yaml

--- a/deploy/02_clusterrole.yaml
+++ b/deploy/02_clusterrole.yaml
@@ -10,6 +10,14 @@ rules:
   verbs:
   - "*"
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - schedulers
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors
@@ -53,6 +61,7 @@ rules:
   - apps
   resources:
   - deployments
+  - deployments/scale
   - replicasets
   verbs:
   - "*"

--- a/deploy/05_deployment.yaml
+++ b/deploy/05_deployment.yaml
@@ -32,6 +32,6 @@ spec:
             - name: OPERATOR_NAME
               value: "descheduler-operator"
             - name: IMAGE
-              value: quay.io/openshift/origin-descheduler:4.7
+              value: quay.io/openshift/origin-descheduler:4.9
       serviceAccountName: openshift-descheduler
       serviceAccount: openshift-descheduler

--- a/manifests/4.9/cluster-kube-descheduler-operator.v4.9.0.clusterserviceversion.yaml
+++ b/manifests/4.9/cluster-kube-descheduler-operator.v4.9.0.clusterserviceversion.yaml
@@ -108,6 +108,14 @@ spec:
           verbs:
           - "*"
         - apiGroups:
+          - config.openshift.io
+          resources:
+          - schedulers
+          verbs:
+          - get
+          - watch
+          - list
+        - apiGroups:
           - monitoring.coreos.com
           resources:
           - servicemonitors
@@ -151,6 +159,7 @@ spec:
           - apps
           resources:
           - deployments
+          - deployments/scale
           - replicasets
           verbs:
           - "*"

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -74,6 +74,7 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 
 	klog.Infof("Starting informers")
 	operatorConfigInformers.Start(ctx.Done())
+	configInformers.Start(ctx.Done())
 	kubeInformersForNamespaces.Start(ctx.Done())
 
 	klog.Infof("Starting log level controller")


### PR DESCRIPTION
Fixes error caused by https://github.com/openshift/cluster-kube-descheduler-operator/pull/202, which forgot to start the new informer and add permissions for the `scheduler.config.openshift.io` API group