### PR TITLE
bug 1992478: Set served=false for v1beta1 crd

### DIFF
--- a/manifests/4.8/kube-descheduler-operator.crd.yaml
+++ b/manifests/4.8/kube-descheduler-operator.crd.yaml
@@ -293,7 +293,7 @@ spec:
                 type: string
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}


### PR DESCRIPTION
Given 4.9 removes v1beta1 version, the OLM complains with
"CRD removes version v1beta1 that is listed as a stored version on the existing CRD".
Based on https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#overview
we need to set served=false in v1beta1 version before it can be removed.