### PR TITLE
Bug 1995951: Fix olm.skipRange substitution

### DIFF
--- a/manifests/4.6/cluster-kube-descheduler-operator.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/4.6/cluster-kube-descheduler-operator.v4.6.0.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     certified: "false"
     containerImage: quay.io/openshift/origin-cluster-kube-descheduler-operator:4.6
     createdAt: 2020/04/18
-    olm.skipRange: ">=4.3.0-0 <4.6.0"
+    olm.skipRange: ">=4.3.0 <4.6.0"
     description: An operator to run descheduler in Openshift cluster.
     repository: https://github.com/openshift/cluster-kube-descheduler-operator
     support: Red Hat, Inc.

--- a/manifests/art.yaml
+++ b/manifests/art.yaml
@@ -7,8 +7,8 @@ updates:
     # replace entire version line, otherwise would replace {MAJOR}.{MINOR}.0 anywhere
     - search: "version: {MAJOR}.{MINOR}.0"
       replace: "version: {FULL_VER}"
-    - search: 'olm.skipRange: ">=4.4.0 <{MAJOR}.{MINOR}.0"'
-      replace: 'olm.skipRange: ">=4.4.0 <{FULL_VER}"'
+    - search: 'olm.skipRange: ">=4.3.0 <{MAJOR}.{MINOR}.0"'
+      replace: 'olm.skipRange: ">=4.3.0 <{FULL_VER}"'
   - file: "cluster-kube-descheduler-operator.package.yaml"
     update_list:
     - search: "currentCSV: cluster-kube-descheduler-operator.v{MAJOR}.{MINOR}.0"


### PR DESCRIPTION
`olm.skipRange` substitution as defined in `manifests/art.yml` has been a noop. This fixes it.