### PR TITLE
Bug 1997787: Rename DoNotEvictPodsWithPVC->EvictPodsWithPVC

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The following profiles are currently provided:
 * [`TopologyAndDuplicates`](#TopologyAndDuplicates)
 * [`SoftTopologyAndDuplicates`](#SoftTopologyAndDuplicates)
 * [`LifecycleAndUtilization`](#LifecycleAndUtilization)
-* [`DoNotEvictPodsWithPVC`](#DoNotEvictPodsWithPVC)
+* [`EvictPodsWithPVC`](#EvictPodsWithPVC)
 * [`EvictPodsWithLocalStorage`](#EvictPodsWithLocalStorage)
   
 Along with the following profiles, which are in development and may change:
@@ -118,10 +118,10 @@ may be made available through the operator for these strategies based on user fe
 This profile provides cluster resource balancing similar to [LifecycleAndUtilization](#LifecycleAndUtilization) for longer-running 
 clusters. It does not evict pods based on the 24 hour lifetime used by LifecycleAndUtilization.
 
-### DoNotEvictPodsWithPVC
-This profile is intended to be used in combination with any of the above profiles to prevent
-them from evicting pods that have PVCs. Without this profile, these pods are eligible
-to be evicted by any profile.
+### EvictPodsWithPVC
+By default, the operator prevents pods with PVCs from being evicted. Enabling this 
+profile in combination with any of the above profiles allows pods with PVCs to be 
+eligible for eviction.
 
 ### EvictPodsWithLocalStorage
 By default, pods with local storage are not eligible to be considered for eviction by any

--- a/bindata/assets/profiles/EvictPodsWithPVC.yaml
+++ b/bindata/assets/profiles/EvictPodsWithPVC.yaml
@@ -1,3 +1,3 @@
 apiVersion: "descheduler/v1alpha1"
 kind: "DeschedulerPolicy"
-ignorePvcPods: true
+ignorePvcPods: false

--- a/manifests/4.9/cluster-kube-descheduler-operator.v4.9.0.clusterserviceversion.yaml
+++ b/manifests/4.9/cluster-kube-descheduler-operator.v4.9.0.clusterserviceversion.yaml
@@ -61,7 +61,7 @@ spec:
       * TopologyAndDuplicates
       * SoftTopologyAndDuplicates
       * LifecycleAndUtilization
-      * DoNotEvictPodsWithPVC
+      * EvictPodsWithPVC
       * EvictPodsWithLocalStorage
 
       These profiles are documented in detail in the [descheduler operator README](https://github.com/openshift/cluster-kube-descheduler-operator#profiles).

--- a/manifests/4.9/kube-descheduler-operator.crd.yaml
+++ b/manifests/4.9/kube-descheduler-operator.crd.yaml
@@ -83,7 +83,7 @@ spec:
                       - DevPreviewLongLifecycle
                       - SoftTopologyAndDuplicates
                       - EvictPodsWithLocalStorage
-                      - DoNotEvictPodsWithPVC
+                      - EvictPodsWithPVC
                 unsupportedConfigOverrides:
                   description: 'unsupportedConfigOverrides holds a sparse config that will override any previously set options.  It only needs to be the fields to override it will end up overlaying in the following order: 1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides'
                   type: object

--- a/pkg/apis/descheduler/v1/types_descheduler.go
+++ b/pkg/apis/descheduler/v1/types_descheduler.go
@@ -49,7 +49,7 @@ type ProfileCustomizations struct {
 
 // DeschedulerProfile allows configuring the enabled strategy profiles for the descheduler
 // it allows multiple profiles to be enabled at once, which will have cumulative effects on the cluster.
-// +kubebuilder:validation:Enum=AffinityAndTaints;TopologyAndDuplicates;LifecycleAndUtilization;DevPreviewLongLifecycle;SoftTopologyAndDuplicates;EvictPodsWithLocalStorage;DoNotEvictPodsWithPVC
+// +kubebuilder:validation:Enum=AffinityAndTaints;TopologyAndDuplicates;LifecycleAndUtilization;DevPreviewLongLifecycle;SoftTopologyAndDuplicates;EvictPodsWithLocalStorage;EvictPodsWithPVC
 type DeschedulerProfile string
 
 var (
@@ -71,8 +71,8 @@ var (
 	// EvictPodsWithLocalStorage enables pods with local storage to be evicted by the descheduler by all other profiles
 	EvictPodsWithLocalStorage DeschedulerProfile = "EvictPodsWithLocalStorage"
 
-	// DoNotEvictPodsWithPVC prevents pods with PVCs from being evicted by all other profiles
-	DoNotEvictPodsWithPVC DeschedulerProfile = "DoNotEvictPodsWithPVC"
+	// EvictPodsWithPVC prevents pods with PVCs from being evicted by all other profiles
+	EvictPodsWithPVC DeschedulerProfile = "EvictPodsWithPVC"
 
 	// DevPreviewLongLifecycle handles cluster lifecycle over a long term
 	DevPreviewLongLifecycle DeschedulerProfile = "DevPreviewLongLifecycle"


### PR DESCRIPTION
In https://github.com/openshift/cluster-kube-descheduler-operator/pull/168 we added default behavior to the operator to ignore pods with PVCs (the upstream default is to evict pods with PVCs, but we had a specific bug to ignore them).

Therefore, adding a profile to ignore pods with PVCs was redundant and unclear in context of the existing default behavior of the operator. Before we release `DoNotEvictPodsWithPVC` in 4.9, this changes it to `EvictPodsWithPVC` which allows PVC pods to be evicted.