### PR TITLE
bug 1991938: Add missing RBAC for storageversionmigrations.migration.k8s.io

### DIFF
--- a/manifests/4.8/cluster-kube-descheduler-operator.v4.8.0.clusterserviceversion.yaml
+++ b/manifests/4.8/cluster-kube-descheduler-operator.v4.8.0.clusterserviceversion.yaml
@@ -152,6 +152,12 @@ spec:
           - replicasets
           verbs:
           - "*"
+        - apiGroups:
+          - migration.k8s.io
+          resources:
+          - "storageversionmigrations"
+          verbs:
+          - "*"
       deployments:
       - name: descheduler-operator
         spec:


### PR DESCRIPTION
```
E0915 02:52:11.420001       1 target_config_reconciler.go:425] key failed with : storageversionmigrations.migration.k8s.io "operator-kubedescheduler-storage-version-migration" is forbidden: User "system:serviceaccount:openshift-kube-descheduler-operator:openshift-descheduler" cannot get resource "storageversionmigrations" in API group "migration.k8s.io" at the cluster scope
```