### PR TITLE
[release-4.8] Bug 1991938: Switch to non-protobuf config for migrations client

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -40,7 +40,7 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 	if err != nil {
 		return err
 	}
-	migrationsClient, err := migrationclient.NewForConfig(cc.ProtoKubeConfig)
+	migrationsClient, err := migrationclient.NewForConfig(cc.KubeConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
New error in our attempts to fix this bug: `E1004 10:24:41.091323       1 target_config_reconciler.go:425] key failed with : object *v1alpha1.StorageVersionMigration does not implement the protobuf marshalling interface and cannot be encoded to a protobuf message`