### PR TITLE
[release-4.8] Bug 1991938: Add permissions to get CRDs in config migration

### DIFF
--- a/manifests/4.8/cluster-kube-descheduler-operator.v4.8.0.clusterserviceversion.yaml
+++ b/manifests/4.8/cluster-kube-descheduler-operator.v4.8.0.clusterserviceversion.yaml
@@ -158,6 +158,12 @@ spec:
           - "storageversionmigrations"
           verbs:
           - "*"
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - "customresourcedefinitions"
+          verbs:
+          - "*"
       deployments:
       - name: descheduler-operator
         spec:


### PR DESCRIPTION
Currently 4.8 is reporting this error:
```
E1102 12:07:33.814476       1 target_config_reconciler.go:425] key failed with : customresourcedefinitions.apiextensions.k8s.io "kubedeschedulers.operator.openshift.io" is forbidden: User "system:serviceaccount:openshift-kube-descheduler-operator:openshift-descheduler" cannot get resource "customresourcedefinitions" in API group "apiextensions.k8s.io" at the cluster scope
```

Add this permission to the CSV so that it can properly perform the v1beta1->v1 migration