### PR TITLE
bug 2041581: Allow to set ciphers through observed config

### DIFF
--- a/deploy/0000_00_kube-descheduler-operator.crd.yaml
+++ b/deploy/0000_00_kube-descheduler-operator.crd.yaml
@@ -1,1 +1,1 @@
-../manifests/4.9/kube-descheduler-operator.crd.yaml
+../manifests/4.10/kube-descheduler-operator.crd.yaml

--- a/deploy/02_clusterrole.yaml
+++ b/deploy/02_clusterrole.yaml
@@ -65,3 +65,22 @@ rules:
   - replicasets
   verbs:
   - "*"
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - infrastructures
+  - apiservers
+  verbs:
+  - get
+  - watch
+  - list

--- a/manifests/4.10/cluster-kube-descheduler-operator.v4.10.0.clusterserviceversion.yaml
+++ b/manifests/4.10/cluster-kube-descheduler-operator.v4.10.0.clusterserviceversion.yaml
@@ -167,6 +167,25 @@ spec:
           - replicasets
           verbs:
           - "*"
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - watch
+          - list
+          - create
+          - update
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - infrastructures
+          - apiservers
+          verbs:
+          - get
+          - watch
+          - list
       deployments:
       - name: descheduler-operator
         spec:

--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -1,0 +1,65 @@
+package configobservercontroller
+
+import (
+	configinformers "github.com/openshift/client-go/config/informers/externalversions"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/openshift/cluster-kube-descheduler-operator/pkg/operator/configobservation"
+	"github.com/openshift/cluster-kube-descheduler-operator/pkg/operator/operatorclient"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/configobserver"
+	libgoapiserver "github.com/openshift/library-go/pkg/operator/configobserver/apiserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+type ConfigObserver struct {
+	factory.Controller
+}
+
+func NewConfigObserver(
+	operatorClient v1helpers.OperatorClient,
+	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
+	configInformer configinformers.SharedInformerFactory,
+	resourceSyncer resourcesynccontroller.ResourceSyncer,
+	eventRecorder events.Recorder,
+) *ConfigObserver {
+	interestingNamespaces := []string{
+		operatorclient.OperatorNamespace,
+	}
+
+	informers := []factory.Informer{
+		operatorClient.Informer(),
+		configInformer.Config().V1().Schedulers().Informer(),
+	}
+	for _, ns := range interestingNamespaces {
+		informers = append(informers, kubeInformersForNamespaces.InformersFor(ns).Core().V1().ConfigMaps().Informer())
+	}
+
+	// TODO: This is probably not necessary anymore, please investigate deeper.
+	configMapPreRunCacheSynced := []cache.InformerSynced{}
+	for _, ns := range interestingNamespaces {
+		configMapPreRunCacheSynced = append(configMapPreRunCacheSynced, kubeInformersForNamespaces.InformersFor(ns).Core().V1().ConfigMaps().Informer().HasSynced)
+	}
+
+	c := &ConfigObserver{
+		Controller: configobserver.NewConfigObserver(
+			operatorClient,
+			eventRecorder,
+			configobservation.Listers{
+				APIServerLister_: configInformer.Config().V1().APIServers().Lister(),
+				ConfigmapLister:  kubeInformersForNamespaces.ConfigMapLister(),
+				ResourceSync:     resourceSyncer,
+				PreRunCachesSynced: append(configMapPreRunCacheSynced,
+					operatorClient.Informer().HasSynced,
+					configInformer.Config().V1().Schedulers().Informer().HasSynced,
+				),
+			},
+			informers,
+			libgoapiserver.ObserveTLSSecurityProfile,
+		),
+	}
+
+	return c
+}

--- a/pkg/operator/configobservation/interfaces.go
+++ b/pkg/operator/configobservation/interfaces.go
@@ -1,0 +1,28 @@
+package configobservation
+
+import (
+	corelistersv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
+)
+
+type Listers struct {
+	ConfigmapLister    corelistersv1.ConfigMapLister
+	APIServerLister_   configlistersv1.APIServerLister
+	ResourceSync       resourcesynccontroller.ResourceSyncer
+	PreRunCachesSynced []cache.InformerSynced
+}
+
+func (l Listers) ResourceSyncer() resourcesynccontroller.ResourceSyncer {
+	return l.ResourceSync
+}
+
+func (l Listers) PreRunHasSynced() []cache.InformerSynced {
+	return l.PreRunCachesSynced
+}
+
+func (l Listers) APIServerLister() configlistersv1.APIServerLister {
+	return l.APIServerLister_
+}

--- a/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
@@ -1,0 +1,26 @@
+package resourcesynccontroller
+
+import (
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+func NewResourceSyncController(
+	operatorConfigClient v1helpers.OperatorClient,
+	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
+	kubeClient kubernetes.Interface,
+	eventRecorder events.Recorder) (*resourcesynccontroller.ResourceSyncController, error) {
+
+	resourceSyncController := resourcesynccontroller.NewResourceSyncController(
+		operatorConfigClient,
+		kubeInformersForNamespaces,
+		v1helpers.CachedSecretGetter(kubeClient.CoreV1(), kubeInformersForNamespaces),
+		v1helpers.CachedConfigMapGetter(kubeClient.CoreV1(), kubeInformersForNamespaces),
+		eventRecorder,
+	)
+
+	return resourceSyncController, nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/condition/condition.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/condition/condition.go
@@ -1,0 +1,72 @@
+package condition
+
+const (
+	// ManagementStateDegradedConditionType is true when the operator ManagementState is not "Managed"..
+	// Possible reasons are Unmanaged, Removed or Unknown. Any of these cases means the operator is not actively managing the operand.
+	// This condition is set to false when the ManagementState is set to back to "Managed".
+	ManagementStateDegradedConditionType = "ManagementStateDegraded"
+
+	// UnsupportedConfigOverridesUpgradeableConditionType is true when operator unsupported config overrides is changed.
+	// When NoUnsupportedConfigOverrides reason is given it means there are no unsupported config overrides.
+	// When UnsupportedConfigOverridesSet reason is given it means the unsupported config overrides are set, which might impact the ability
+	// of operator to successfully upgrade its operand.
+	UnsupportedConfigOverridesUpgradeableConditionType = "UnsupportedConfigOverridesUpgradeable"
+
+	// MonitoringResourceControllerDegradedConditionType is true when the operator is unable to create or reconcile the ServiceMonitor
+	// CR resource, which is required by monitoring operator to collect Prometheus data from the operator. When this condition is true and the ServiceMonitor
+	// is already created, it won't have impact on collecting metrics. However, if the ServiceMonitor was not created, the metrics won't be available for
+	// collection until this condition is set to false.
+	// The condition is set to false automatically when the operator successfully synchronize the ServiceMonitor resource.
+	MonitoringResourceControllerDegradedConditionType = "MonitoringResourceControllerDegraded"
+
+	// BackingResourceControllerDegradedConditionType is true when the operator is unable to create or reconcile the resources needed
+	// to successfully run the installer pods (installer CRB and SA). If these were already created, this condition is not fatal, however if the resources
+	// were not created it means the installer pod creation will fail.
+	// This condition is set to false when the operator can successfully synchronize installer SA and CRB.
+	BackingResourceControllerDegradedConditionType = "BackingResourceControllerDegraded"
+
+	// StaticPodsDegradedConditionType is true when the operator observe errors when installing the new revision static pods.
+	// This condition report Error reason when the pods are terminated or not ready or waiting during which the operand quality of service is degraded.
+	// This condition is set to False when the pods change state to running and are observed ready.
+	StaticPodsDegradedConditionType = "StaticPodsDegraded"
+
+	// StaticPodsAvailableConditionType is true when the static pod is available on at least one node.
+	StaticPodsAvailableConditionType = "StaticPodsAvailable"
+
+	// ConfigObservationDegradedConditionType is true when the operator failed to observe or process configuration change.
+	// This is not transient condition and normally a correction or manual intervention is required on the config custom resource.
+	ConfigObservationDegradedConditionType = "ConfigObservationDegraded"
+
+	// ResourceSyncControllerDegradedConditionType is true when the operator failed to synchronize one or more secrets or config maps required
+	// to run the operand. Operand ability to provide service might be affected by this condition.
+	// This condition is set to false when the operator is able to create secrets and config maps.
+	ResourceSyncControllerDegradedConditionType = "ResourceSyncControllerDegraded"
+
+	// CertRotationDegradedConditionTypeFmt is true when the operator failed to properly rotate one or more certificates required by the operand.
+	// The RotationError reason is given with message describing details of this failure. This condition can be fatal when ignored as the existing certificate(s)
+	// validity can expire and without rotating/renewing them manual recovery might be required to fix the cluster.
+	CertRotationDegradedConditionTypeFmt = "CertRotation_%s_Degraded"
+
+	// InstallerControllerDegradedConditionType is true when the operator is not able to create new installer pods so the new revisions
+	// cannot be rolled out. This might happen when one or more required secrets or config maps does not exists.
+	// In case the missing secret or config map is available, this condition is automatically set to false.
+	InstallerControllerDegradedConditionType = "InstallerControllerDegraded"
+
+	// NodeInstallerDegradedConditionType is true when the operator is not able to create new installer pods because there are no schedulable nodes
+	// available to run the installer pods.
+	// The AllNodesAtLatestRevision reason is set when all master nodes are updated to the latest revision. It is false when some masters are pending revision.
+	// ZeroNodesActive reason is set to True when no active master nodes are observed. Is set to False when there is at least one active master node.
+	NodeInstallerDegradedConditionType = "NodeInstallerDegraded"
+
+	// NodeInstallerProgressingConditionType is true when the operator is moving nodes to a new revision.
+	NodeInstallerProgressingConditionType = "NodeInstallerProgressing"
+
+	// RevisionControllerDegradedConditionType is true when the operator is not able to create new desired revision because an error occurred when
+	// the operator attempted to created required resource(s) (secrets, configmaps, ...).
+	// This condition mean no new revision will be created.
+	RevisionControllerDegradedConditionType = "RevisionControllerDegraded"
+
+	// NodeControllerDegradedConditionType is true when the operator observed a master node that is not ready.
+	// Note that a node is not ready when its Condition.NodeReady wasn't set to true
+	NodeControllerDegradedConditionType = "NodeControllerDegraded"
+)

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/apiserver/OWNERS
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/apiserver/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+  - tkashem
+  - p0lyn0mial
+  - sttts
+approvers:
+  - tkashem
+  - p0lyn0mial
+  - sttts

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/apiserver/listers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/apiserver/listers.go
@@ -1,0 +1,9 @@
+package apiserver
+
+import (
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+)
+
+type APIServerLister interface {
+	APIServerLister() configlistersv1.APIServerLister
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/apiserver/observe_audit.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/apiserver/observe_audit.go
@@ -1,0 +1,88 @@
+package apiserver
+
+import (
+	"fmt"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/library-go/pkg/operator/configobserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+// AuditPolicyPathGetterFunc allows the observer to be agnostic of the source of audit profile(s).
+// The function returns the path to the audit policy file (associated with the
+// given profile) in the static manifest folder.
+type AuditPolicyPathGetterFunc func(profile string) (string, error)
+
+// NewAuditObserver returns an ObserveConfigFunc that observes the audit field of the APIServer resource
+// and sets the apiServerArguments:audit-policy-file field for the apiserver appropriately.
+func NewAuditObserver(pathGetter AuditPolicyPathGetterFunc) configobserver.ObserveConfigFunc {
+	var (
+		apiServerArgumentsAuditPath = []string{"apiServerArguments", "audit-policy-file"}
+	)
+
+	return func(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (observed map[string]interface{}, _ []error) {
+		defer func() {
+			observed = configobserver.Pruned(observed, apiServerArgumentsAuditPath)
+		}()
+
+		errs := []error{}
+
+		// if the function encounters an error it returns existing/current config, which means that
+		// some other entity (default config in bindata ) must ensure to default the configuration.
+		// otherwise, the apiserver won't have a path to audit policy file and it will fail to start.
+		listers := genericListers.(APIServerLister)
+		apiServer, err := listers.APIServerLister().Get("cluster")
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				klog.Warningf("apiserver.config.openshift.io/cluster: not found")
+
+				return existingConfig, errs
+			}
+
+			return existingConfig, append(errs, err)
+		}
+
+		desiredProfile := string(apiServer.Spec.Audit.Profile)
+		if len(desiredProfile) == 0 {
+			// The specified Profile is empty, so let the defaulting layer choose a default for us.
+			return map[string]interface{}{}, errs
+		}
+
+		desiredAuditPolicyPath, err := pathGetter(desiredProfile)
+		if err != nil {
+			return existingConfig, append(errs, fmt.Errorf("audit profile is not valid name=%s", desiredProfile))
+		}
+
+		currentAuditPolicyPath, err := getCurrentPolicyPath(existingConfig, apiServerArgumentsAuditPath...)
+		if err != nil {
+			return existingConfig, append(errs, fmt.Errorf("audit profile is not valid name=%s", desiredProfile))
+		}
+		if desiredAuditPolicyPath == currentAuditPolicyPath {
+			return existingConfig, errs
+		}
+
+		// we have a change of audit policy here!
+		observedConfig := map[string]interface{}{}
+		if err := unstructured.SetNestedStringSlice(observedConfig, []string{desiredAuditPolicyPath}, apiServerArgumentsAuditPath...); err != nil {
+			return existingConfig, append(errs, fmt.Errorf("failed to set desired audit profile in observed config name=%s", desiredProfile))
+		}
+
+		recorder.Eventf("ObserveAPIServerArgumentsAudit", "audit policy has been set to profile=%s", desiredProfile)
+		return observedConfig, errs
+	}
+}
+
+func getCurrentPolicyPath(existing map[string]interface{}, fields ...string) (string, error) {
+	current, _, err := unstructured.NestedStringSlice(existing, fields...)
+	if err != nil {
+		return "", err
+	}
+	if len(current) == 0 {
+		return "", nil
+	}
+
+	return current[0], nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/apiserver/observe_cors.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/apiserver/observe_cors.go
@@ -1,0 +1,75 @@
+package apiserver
+
+import (
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/library-go/pkg/operator/configobserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+var clusterDefaultCORSAllowedOrigins = []string{
+	`//127\.0\.0\.1(:|$)`,
+	`//localhost(:|$)`,
+}
+
+// ObserveAdditionalCORSAllowedOrigins observes the additionalCORSAllowedOrigins field
+// of the APIServer resource and sets the corsAllowedOrigins field of observedConfig
+func ObserveAdditionalCORSAllowedOrigins(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
+	return innerObserveAdditionalCORSAllowedOrigins(genericListers, recorder, existingConfig, []string{"corsAllowedOrigins"})
+}
+
+// ObserveAdditionalCORSAllowedOriginsToArguments observes the additionalCORSAllowedOrigins field
+// of the APIServer resource and sets the cors-allowed-origins field in observedConfig.apiServerArguments
+func ObserveAdditionalCORSAllowedOriginsToArguments(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
+	return innerObserveAdditionalCORSAllowedOrigins(genericListers, recorder, existingConfig, []string{"apiServerArguments", "cors-allowed-origins"})
+}
+
+func innerObserveAdditionalCORSAllowedOrigins(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}, corsAllowedOriginsPath []string) (ret map[string]interface{}, _ []error) {
+	defer func() {
+		ret = configobserver.Pruned(ret, corsAllowedOriginsPath)
+	}()
+
+	lister := genericListers.(APIServerLister)
+	errs := []error{}
+	defaultConfig := map[string]interface{}{}
+	if err := unstructured.SetNestedStringSlice(defaultConfig, clusterDefaultCORSAllowedOrigins, corsAllowedOriginsPath...); err != nil {
+		// this should not happen
+		return existingConfig, append(errs, err)
+	}
+
+	// grab the current CORS origins to later check whether they were updated
+	currentCORSAllowedOrigins, _, err := unstructured.NestedStringSlice(existingConfig, corsAllowedOriginsPath...)
+	if err != nil {
+		errs = append(errs, err)
+		// keep going on read error from existing config
+	}
+	currentCORSSet := sets.NewString(currentCORSAllowedOrigins...)
+	currentCORSSet.Insert(clusterDefaultCORSAllowedOrigins...)
+
+	observedConfig := map[string]interface{}{}
+	apiServer, err := lister.APIServerLister().Get("cluster")
+	if errors.IsNotFound(err) {
+		klog.Warningf("apiserver.config.openshift.io/cluster: not found")
+		return defaultConfig, errs
+	}
+	if err != nil {
+		// return existingConfig here in case err is just a transient error so
+		// that we don't rewrite the config that was observed previously
+		return existingConfig, append(errs, err)
+	}
+
+	newCORSSet := sets.NewString(clusterDefaultCORSAllowedOrigins...)
+	newCORSSet.Insert(apiServer.Spec.AdditionalCORSAllowedOrigins...)
+	if err := unstructured.SetNestedStringSlice(observedConfig, newCORSSet.List(), corsAllowedOriginsPath...); err != nil {
+		return existingConfig, append(errs, err)
+	}
+
+	if !currentCORSSet.Equal(newCORSSet) {
+		recorder.Eventf("ObserveAdditionalCORSAllowedOrigins", "corsAllowedOrigins changed to %q", newCORSSet.List())
+	}
+
+	return observedConfig, errs
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/apiserver/observe_tlssecurityprofile.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/apiserver/observe_tlssecurityprofile.go
@@ -1,0 +1,103 @@
+package apiserver
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/klog/v2"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/crypto"
+	"github.com/openshift/library-go/pkg/operator/configobserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// ObserveTLSSecurityProfile observes APIServer.Spec.TLSSecurityProfile field and sets
+// the ServingInfo.MinTLSVersion, ServingInfo.CipherSuites fields of observed config
+func ObserveTLSSecurityProfile(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
+	return innerTLSSecurityProfileObservations(genericListers, recorder, existingConfig, []string{"servingInfo", "minTLSVersion"}, []string{"servingInfo", "cipherSuites"})
+}
+
+// ObserveTLSSecurityProfileToArguments observes APIServer.Spec.TLSSecurityProfile field and sets
+// the tls-min-version and tls-cipher-suites fileds of observedConfig.apiServerArguments
+func ObserveTLSSecurityProfileToArguments(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
+	return innerTLSSecurityProfileObservations(genericListers, recorder, existingConfig, []string{"apiServerArguments", "tls-min-version"}, []string{"apiServerArguments", "tls-cipher-suites"})
+}
+
+func innerTLSSecurityProfileObservations(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}, minTLSVersionPath, cipherSuitesPath []string) (ret map[string]interface{}, _ []error) {
+	defer func() {
+		ret = configobserver.Pruned(ret, minTLSVersionPath, cipherSuitesPath)
+	}()
+
+	listers := genericListers.(APIServerLister)
+	errs := []error{}
+
+	currentMinTLSVersion, _, versionErr := unstructured.NestedString(existingConfig, minTLSVersionPath...)
+	if versionErr != nil {
+		errs = append(errs, fmt.Errorf("failed to retrieve spec.servingInfo.minTLSVersion: %v", versionErr))
+		// keep going on read error from existing config
+	}
+
+	currentCipherSuites, _, suitesErr := unstructured.NestedStringSlice(existingConfig, cipherSuitesPath...)
+	if suitesErr != nil {
+		errs = append(errs, fmt.Errorf("failed to retrieve spec.servingInfo.cipherSuites: %v", suitesErr))
+		// keep going on read error from existing config
+	}
+
+	apiServer, err := listers.APIServerLister().Get("cluster")
+	if errors.IsNotFound(err) {
+		klog.Warningf("apiserver.config.openshift.io/cluster: not found")
+		apiServer = &configv1.APIServer{}
+	} else if err != nil {
+		return existingConfig, append(errs, err)
+	}
+
+	observedConfig := map[string]interface{}{}
+	observedMinTLSVersion, observedCipherSuites := getSecurityProfileCiphers(apiServer.Spec.TLSSecurityProfile)
+	if err = unstructured.SetNestedField(observedConfig, observedMinTLSVersion, minTLSVersionPath...); err != nil {
+		return existingConfig, append(errs, err)
+	}
+	if err = unstructured.SetNestedStringSlice(observedConfig, observedCipherSuites, cipherSuitesPath...); err != nil {
+		return existingConfig, append(errs, err)
+	}
+
+	if observedMinTLSVersion != currentMinTLSVersion {
+		recorder.Eventf("ObserveTLSSecurityProfile", "minTLSVersion changed to %s", observedMinTLSVersion)
+	}
+	if !reflect.DeepEqual(observedCipherSuites, currentCipherSuites) {
+		recorder.Eventf("ObserveTLSSecurityProfile", "cipherSuites changed to %q", observedCipherSuites)
+	}
+
+	return observedConfig, errs
+}
+
+// Extracts the minimum TLS version and cipher suites from TLSSecurityProfile object,
+// Converts the ciphers to IANA names as supported by Kube ServingInfo config.
+// If profile is nil, returns config defined by the Intermediate TLS Profile
+func getSecurityProfileCiphers(profile *configv1.TLSSecurityProfile) (string, []string) {
+	var profileType configv1.TLSProfileType
+	if profile == nil {
+		profileType = configv1.TLSProfileIntermediateType
+	} else {
+		profileType = profile.Type
+	}
+
+	var profileSpec *configv1.TLSProfileSpec
+	if profileType == configv1.TLSProfileCustomType {
+		if profile.Custom != nil {
+			profileSpec = &profile.Custom.TLSProfileSpec
+		}
+	} else {
+		profileSpec = configv1.TLSProfiles[profileType]
+	}
+
+	// nothing found / custom type set but no actual custom spec
+	if profileSpec == nil {
+		profileSpec = configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+	}
+
+	// need to remap all Ciphers to their respective IANA names used by Go
+	return string(profileSpec.MinTLSVersion), crypto.OpenSSLToIANACipherSuites(profileSpec.Ciphers)
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/config_observer_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/config_observer_controller.go
@@ -1,0 +1,284 @@
+package configobserver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/imdario/mergo"
+	"k8s.io/klog/v2"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/tools/cache"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/condition"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/management"
+	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+// Listers is an interface which will be passed to the config observer funcs.  It is expected to be hard-cast to the "correct" type
+type Listers interface {
+	// ResourceSyncer can be used to copy content from one namespace to another
+	ResourceSyncer() resourcesynccontroller.ResourceSyncer
+	PreRunHasSynced() []cache.InformerSynced
+}
+
+// ObserveConfigFunc observes configuration and returns the observedConfig. This function should not return an
+// observedConfig that would cause the service being managed by the operator to crash. For example, if a required
+// configuration key cannot be observed, consider reusing the configuration key's previous value. Errors that occur
+// while attempting to generate the observedConfig should be returned in the errs slice.
+type ObserveConfigFunc func(listers Listers, recorder events.Recorder, existingConfig map[string]interface{}) (observedConfig map[string]interface{}, errs []error)
+
+type ConfigObserver struct {
+	// observers are called in an undefined order and their results are merged to
+	// determine the observed configuration.
+	observers []ObserveConfigFunc
+
+	operatorClient v1helpers.OperatorClient
+
+	// listers are used by config observers to retrieve necessary resources
+	listers Listers
+
+	nestedConfigPath      []string
+	degradedConditionType string
+}
+
+func NewConfigObserver(
+	operatorClient v1helpers.OperatorClient,
+	eventRecorder events.Recorder,
+	listers Listers,
+	informers []factory.Informer,
+	observers ...ObserveConfigFunc,
+) factory.Controller {
+	return NewNestedConfigObserver(
+		operatorClient,
+		eventRecorder,
+		listers,
+		informers,
+		nil,
+		"",
+		observers...,
+	)
+}
+
+// NewNestedConfigObserver creates a config observer that watches changes to a nested field (nestedConfigPath) in the config.
+// Useful when the config is shared across multiple controllers in the same process.
+//
+// Example:
+//
+// Given the following configuration, you could run two separate controllers and point each to its own section.
+// The first controller would be responsible for "oauthAPIServer" and the second for "oauthServer" section.
+//
+// "observedConfig": {
+//   "oauthAPIServer": {
+//     "apiServerArguments": {"tls-min-version": "VersionTLS12"}
+//   },
+//   "oauthServer": {
+//     "corsAllowedOrigins": [ "//127\\.0\\.0\\.1(:|$)","//localhost(:|$)"]
+//   }
+// }
+//
+// oauthAPIController    := NewNestedConfigObserver(..., []string{"oauthAPIServer"}
+// oauthServerController := NewNestedConfigObserver(..., []string{"oauthServer"}
+func NewNestedConfigObserver(
+	operatorClient v1helpers.OperatorClient,
+	eventRecorder events.Recorder,
+	listers Listers,
+	informers []factory.Informer,
+	nestedConfigPath []string,
+	degradedConditionPrefix string,
+	observers ...ObserveConfigFunc,
+) factory.Controller {
+	c := &ConfigObserver{
+		operatorClient:        operatorClient,
+		observers:             observers,
+		listers:               listers,
+		nestedConfigPath:      nestedConfigPath,
+		degradedConditionType: degradedConditionPrefix + condition.ConfigObservationDegradedConditionType,
+	}
+
+	return factory.New().ResyncEvery(time.Minute).WithSync(c.sync).WithInformers(append(informers, listersToInformer(listers)...)...).ToController("ConfigObserver", eventRecorder.WithComponentSuffix("config-observer"))
+}
+
+// sync reacts to a change in prereqs by finding information that is required to match another value in the cluster. This
+// must be information that is logically "owned" by another component.
+func (c ConfigObserver) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	originalSpec, _, _, err := c.operatorClient.GetOperatorState()
+	if management.IsOperatorRemovable() && apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	spec := originalSpec.DeepCopy()
+
+	// don't worry about errors.  If we can't decode, we'll simply stomp over the field.
+	existingConfig := map[string]interface{}{}
+	if err := json.NewDecoder(bytes.NewBuffer(spec.ObservedConfig.Raw)).Decode(&existingConfig); err != nil {
+		klog.V(4).Infof("decode of existing config failed with error: %v", err)
+	}
+
+	var errs []error
+	var observedConfigs []map[string]interface{}
+	for _, i := range rand.Perm(len(c.observers)) {
+		var currErrs []error
+		observedConfig, currErrs := c.observers[i](c.listers, syncCtx.Recorder(), existingConfig)
+		observedConfigs = append(observedConfigs, observedConfig)
+		errs = append(errs, currErrs...)
+	}
+
+	mergedObservedConfig := map[string]interface{}{}
+	for _, observedConfig := range observedConfigs {
+		if err := mergo.Merge(&mergedObservedConfig, observedConfig); err != nil {
+			klog.Warningf("merging observed config failed: %v", err)
+		}
+	}
+
+	reverseMergedObservedConfig := map[string]interface{}{}
+	for i := len(observedConfigs) - 1; i >= 0; i-- {
+		if err := mergo.Merge(&reverseMergedObservedConfig, observedConfigs[i]); err != nil {
+			klog.Warningf("merging observed config failed: %v", err)
+		}
+	}
+
+	if !equality.Semantic.DeepEqual(mergedObservedConfig, reverseMergedObservedConfig) {
+		errs = append(errs, errors.New("non-deterministic config observation detected"))
+	}
+
+	if err := c.updateObservedConfig(ctx, syncCtx, existingConfig, mergedObservedConfig); err != nil {
+		errs = []error{err}
+	}
+	configError := v1helpers.NewMultiLineAggregate(errs)
+
+	// update failing condition
+	cond := operatorv1.OperatorCondition{
+		Type:   c.degradedConditionType,
+		Status: operatorv1.ConditionFalse,
+	}
+	if configError != nil {
+		cond.Status = operatorv1.ConditionTrue
+		cond.Reason = "Error"
+		cond.Message = configError.Error()
+	}
+	if _, _, updateError := v1helpers.UpdateStatus(ctx, c.operatorClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
+		return updateError
+	}
+
+	return configError
+}
+
+func (c ConfigObserver) updateObservedConfig(ctx context.Context, syncCtx factory.SyncContext, existingConfig map[string]interface{}, mergedObservedConfig map[string]interface{}) error {
+	if len(c.nestedConfigPath) == 0 {
+		if !equality.Semantic.DeepEqual(existingConfig, mergedObservedConfig) {
+			syncCtx.Recorder().Eventf("ObservedConfigChanged", "Writing updated observed config: %v", diff.ObjectDiff(existingConfig, mergedObservedConfig))
+			return c.updateConfig(ctx, syncCtx, mergedObservedConfig, v1helpers.UpdateObservedConfigFn)
+		}
+		return nil
+	}
+
+	existingConfigNested, _, err := unstructured.NestedMap(existingConfig, c.nestedConfigPath...)
+	if err != nil {
+		return fmt.Errorf("unable to extract the config under %v key, err %v", c.nestedConfigPath, err)
+	}
+	mergedObservedConfigNested, _, err := unstructured.NestedMap(mergedObservedConfig, c.nestedConfigPath...)
+	if err != nil {
+		return fmt.Errorf("unable to extract the merged config under %v, err %v", c.nestedConfigPath, err)
+	}
+	if !equality.Semantic.DeepEqual(existingConfigNested, mergedObservedConfigNested) {
+		syncCtx.Recorder().Eventf("ObservedConfigChanged", "Writing updated section (%q) of observed config: %q", strings.Join(c.nestedConfigPath, "/"), diff.ObjectDiff(existingConfigNested, mergedObservedConfigNested))
+		return c.updateConfig(ctx, syncCtx, mergedObservedConfigNested, c.updateNestedConfigHelper)
+	}
+	return nil
+}
+
+type updateObservedConfigFn func(config map[string]interface{}) v1helpers.UpdateOperatorSpecFunc
+
+func (c ConfigObserver) updateConfig(ctx context.Context, syncCtx factory.SyncContext, updatedMaybeNestedConfig map[string]interface{}, updateConfigHelper updateObservedConfigFn) error {
+	if _, _, err := v1helpers.UpdateSpec(ctx, c.operatorClient, updateConfigHelper(updatedMaybeNestedConfig)); err != nil {
+		// At this point we failed to write the updated config. If we are permanently broken, do not pile the errors from observers
+		// but instead reset the errors and only report single error condition.
+		syncCtx.Recorder().Warningf("ObservedConfigWriteError", "Failed to write observed config: %v", err)
+		return fmt.Errorf("error writing updated observed config: %v", err)
+	}
+	return nil
+}
+
+// updateNestedConfigHelper returns a helper function for updating the nested config.
+func (c ConfigObserver) updateNestedConfigHelper(updatedNestedConfig map[string]interface{}) v1helpers.UpdateOperatorSpecFunc {
+	return func(currentSpec *operatorv1.OperatorSpec) error {
+		existingConfig := map[string]interface{}{}
+		if err := json.NewDecoder(bytes.NewBuffer(currentSpec.ObservedConfig.Raw)).Decode(&existingConfig); err != nil {
+			klog.V(4).Infof("decode of existing config failed with error: %v", err)
+		}
+		if err := unstructured.SetNestedField(existingConfig, updatedNestedConfig, c.nestedConfigPath...); err != nil {
+			return fmt.Errorf("unable to set the nested (%q) observed config: %v", strings.Join(c.nestedConfigPath, "/"), err)
+		}
+		currentSpec.ObservedConfig = runtime.RawExtension{Object: &unstructured.Unstructured{Object: existingConfig}}
+		return nil
+	}
+}
+
+// listersToInformer converts the Listers interface to informer with empty AddEventHandler as we only care about synced caches in the Run.
+func listersToInformer(l Listers) []factory.Informer {
+	result := make([]factory.Informer, len(l.PreRunHasSynced()))
+	for i := range l.PreRunHasSynced() {
+		result[i] = &listerInformer{cacheSynced: l.PreRunHasSynced()[i]}
+	}
+	return result
+}
+
+type listerInformer struct {
+	cacheSynced cache.InformerSynced
+}
+
+func (l *listerInformer) AddEventHandler(cache.ResourceEventHandler) {
+	return
+}
+
+func (l *listerInformer) HasSynced() bool {
+	return l.cacheSynced()
+}
+
+// WithPrefix adds a prefix to the path the input observer would otherwise observe into
+func WithPrefix(observer ObserveConfigFunc, prefix ...string) ObserveConfigFunc {
+	if len(prefix) == 0 {
+		return observer
+	}
+
+	return func(listers Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
+		errs := []error{}
+
+		nestedExistingConfig, _, err := unstructured.NestedMap(existingConfig, prefix...)
+		if err != nil {
+			errs = append(errs, err)
+		}
+
+		orig, observerErrs := observer(listers, recorder, nestedExistingConfig)
+		errs = append(errs, observerErrs...)
+
+		if orig == nil {
+			return nil, errs
+		}
+
+		ret := map[string]interface{}{}
+		if err := unstructured.SetNestedField(ret, orig, prefix...); err != nil {
+			errs = append(errs, err)
+		}
+		return ret, errs
+
+	}
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/unstructured.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/unstructured.go
@@ -1,0 +1,45 @@
+package configobserver
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// Pruned returns the unstructured filtered by the given paths, i.e. everything
+// outside of them will be dropped. The returned data structure might overlap
+// with the input, but the input is not mutated. In case of error for a path,
+// that path is dropped.
+func Pruned(obj map[string]interface{}, pths ...[]string) map[string]interface{} {
+	if obj == nil || len(pths) == 0 {
+		return obj
+	}
+
+	ret := map[string]interface{}{}
+	if len(pths) == 1 {
+		x, found, err := unstructured.NestedFieldCopy(obj, pths[0]...)
+		if err != nil || !found {
+			return ret
+		}
+		unstructured.SetNestedField(ret, x, pths[0]...)
+		return ret
+	}
+
+	for i, p := range pths {
+		x, found, err := unstructured.NestedFieldCopy(obj, p...)
+		if err != nil {
+			continue
+		}
+		if !found {
+			continue
+		}
+		if i < len(pths)-1 {
+			// this might be overwritten by a later path
+			x = runtime.DeepCopyJSONValue(x)
+		}
+		if err := unstructured.SetNestedField(ret, x, p...); err != nil {
+			continue
+		}
+	}
+
+	return ret
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/core.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/core.go
@@ -1,0 +1,67 @@
+package resourcesynccontroller
+
+import (
+	"crypto/x509"
+	"fmt"
+	"reflect"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/util/cert"
+
+	"github.com/openshift/library-go/pkg/crypto"
+)
+
+func CombineCABundleConfigMaps(destinationConfigMap ResourceLocation, lister corev1listers.ConfigMapLister, inputConfigMaps ...ResourceLocation) (*corev1.ConfigMap, error) {
+	certificates := []*x509.Certificate{}
+	for _, input := range inputConfigMaps {
+		inputConfigMap, err := lister.ConfigMaps(input.Namespace).Get(input.Name)
+		if apierrors.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		// configmaps must conform to this
+		inputContent := inputConfigMap.Data["ca-bundle.crt"]
+		if len(inputContent) == 0 {
+			continue
+		}
+		inputCerts, err := cert.ParseCertsPEM([]byte(inputContent))
+		if err != nil {
+			return nil, fmt.Errorf("configmap/%s in %q is malformed: %v", input.Name, input.Namespace, err)
+		}
+		certificates = append(certificates, inputCerts...)
+	}
+
+	certificates = crypto.FilterExpiredCerts(certificates...)
+	finalCertificates := []*x509.Certificate{}
+	// now check for duplicates. n^2, but super simple
+	for i := range certificates {
+		found := false
+		for j := range finalCertificates {
+			if reflect.DeepEqual(certificates[i].Raw, finalCertificates[j].Raw) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			finalCertificates = append(finalCertificates, certificates[i])
+		}
+	}
+
+	caBytes, err := crypto.EncodeCertificates(finalCertificates...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: destinationConfigMap.Namespace, Name: destinationConfigMap.Name},
+		Data: map[string]string{
+			"ca-bundle.crt": string(caBytes),
+		},
+	}, nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/interfaces.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/interfaces.go
@@ -1,0 +1,41 @@
+package resourcesynccontroller
+
+import "k8s.io/apimachinery/pkg/util/sets"
+
+// ResourceLocation describes coordinates for a resource to be synced
+type ResourceLocation struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+
+	// Provider if set for the source location enhance the error message to point to the component which
+	// provide this resource.
+	Provider string `json:"provider,omitempty"`
+}
+
+// PreconditionsFulfilled is a function that indicates whether all prerequisites
+// are met and a resource can be synced.
+type preconditionsFulfilled func() (bool, error)
+
+func alwaysFulfilledPreconditions() (bool, error) { return true, nil }
+
+type syncRuleSource struct {
+	ResourceLocation
+	syncedKeys               sets.String            // defines the set of keys to sync from source to dest
+	preconditionsFulfilledFn preconditionsFulfilled // preconditions to fulfill before syncing the resource
+}
+
+type syncRules map[ResourceLocation]syncRuleSource
+
+var (
+	emptyResourceLocation = ResourceLocation{}
+)
+
+// ResourceSyncer allows changes to syncing rules by this controller
+type ResourceSyncer interface {
+	// SyncConfigMap indicates that a configmap should be copied from the source to the destination.  It will also
+	// mirror a deletion from the source.  If the source is a zero object the destination will be deleted.
+	SyncConfigMap(destination, source ResourceLocation) error
+	// SyncSecret indicates that a secret should be copied from the source to the destination.  It will also
+	// mirror a deletion from the source.  If the source is a zero object the destination will be deleted.
+	SyncSecret(destination, source ResourceLocation) error
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/resourcesync_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/resourcesync_controller.go
@@ -1,0 +1,340 @@
+package resourcesynccontroller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/condition"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/management"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+// ResourceSyncController is a controller that will copy source configmaps and secrets to their destinations.
+// It will also mirror deletions by deleting destinations.
+type ResourceSyncController struct {
+	name string
+	// syncRuleLock is used to ensure we avoid races on changes to syncing rules
+	syncRuleLock sync.RWMutex
+	// configMapSyncRules is a map from destination location to source location
+	configMapSyncRules syncRules
+	// secretSyncRules is a map from destination location to source location
+	secretSyncRules syncRules
+
+	// knownNamespaces is the list of namespaces we are watching.
+	knownNamespaces sets.String
+
+	configMapGetter            corev1client.ConfigMapsGetter
+	secretGetter               corev1client.SecretsGetter
+	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces
+	operatorConfigClient       v1helpers.OperatorClient
+
+	runFn   func(ctx context.Context, workers int)
+	syncCtx factory.SyncContext
+}
+
+var _ ResourceSyncer = &ResourceSyncController{}
+var _ factory.Controller = &ResourceSyncController{}
+
+// NewResourceSyncController creates ResourceSyncController.
+func NewResourceSyncController(
+	operatorConfigClient v1helpers.OperatorClient,
+	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
+	secretsGetter corev1client.SecretsGetter,
+	configMapsGetter corev1client.ConfigMapsGetter,
+	eventRecorder events.Recorder,
+) *ResourceSyncController {
+	c := &ResourceSyncController{
+		name:                 "ResourceSyncController",
+		operatorConfigClient: operatorConfigClient,
+
+		configMapSyncRules:         syncRules{},
+		secretSyncRules:            syncRules{},
+		kubeInformersForNamespaces: kubeInformersForNamespaces,
+		knownNamespaces:            kubeInformersForNamespaces.Namespaces(),
+
+		configMapGetter: configMapsGetter,
+		secretGetter:    secretsGetter,
+		syncCtx:         factory.NewSyncContext("ResourceSyncController", eventRecorder.WithComponentSuffix("resource-sync-controller")),
+	}
+
+	informers := []factory.Informer{
+		operatorConfigClient.Informer(),
+	}
+	for namespace := range kubeInformersForNamespaces.Namespaces() {
+		if len(namespace) == 0 {
+			continue
+		}
+		informer := kubeInformersForNamespaces.InformersFor(namespace)
+		informers = append(informers, informer.Core().V1().ConfigMaps().Informer())
+		informers = append(informers, informer.Core().V1().Secrets().Informer())
+	}
+
+	f := factory.New().WithSync(c.Sync).WithSyncContext(c.syncCtx).WithInformers(informers...).ResyncEvery(time.Minute).ToController(c.name, eventRecorder.WithComponentSuffix("resource-sync-controller"))
+	c.runFn = f.Run
+
+	return c
+}
+
+func (c *ResourceSyncController) Run(ctx context.Context, workers int) {
+	c.runFn(ctx, workers)
+}
+
+func (c *ResourceSyncController) Name() string {
+	return c.name
+}
+
+func (c *ResourceSyncController) SyncConfigMap(destination, source ResourceLocation) error {
+	return c.syncConfigMap(destination, source, alwaysFulfilledPreconditions)
+}
+
+func (c *ResourceSyncController) SyncPartialConfigMap(destination ResourceLocation, source ResourceLocation, keys ...string) error {
+	return c.syncConfigMap(destination, source, alwaysFulfilledPreconditions, keys...)
+}
+
+// SyncConfigMapConditionally adds a new configmap that the resource sync
+// controller will synchronise if the given precondition is fulfilled.
+func (c *ResourceSyncController) SyncConfigMapConditionally(destination, source ResourceLocation, preconditionsFulfilledFn preconditionsFulfilled) error {
+	return c.syncConfigMap(destination, source, preconditionsFulfilledFn)
+}
+
+func (c *ResourceSyncController) syncConfigMap(destination ResourceLocation, source ResourceLocation, preconditionsFulfilledFn preconditionsFulfilled, keys ...string) error {
+	if !c.knownNamespaces.Has(destination.Namespace) {
+		return fmt.Errorf("not watching namespace %q", destination.Namespace)
+	}
+	if source != emptyResourceLocation && !c.knownNamespaces.Has(source.Namespace) {
+		return fmt.Errorf("not watching namespace %q", source.Namespace)
+	}
+
+	c.syncRuleLock.Lock()
+	defer c.syncRuleLock.Unlock()
+	c.configMapSyncRules[destination] = syncRuleSource{
+		ResourceLocation:         source,
+		syncedKeys:               sets.NewString(keys...),
+		preconditionsFulfilledFn: preconditionsFulfilledFn,
+	}
+
+	// make sure the new rule is picked up
+	c.syncCtx.Queue().Add(c.syncCtx.QueueKey())
+	return nil
+}
+
+func (c *ResourceSyncController) SyncSecret(destination, source ResourceLocation) error {
+	return c.syncSecret(destination, source, alwaysFulfilledPreconditions)
+}
+
+func (c *ResourceSyncController) SyncPartialSecret(destination, source ResourceLocation, keys ...string) error {
+	return c.syncSecret(destination, source, alwaysFulfilledPreconditions, keys...)
+}
+
+// SyncSecretConditionally adds a new secret that the resource sync controller
+// will synchronise if the given precondition is fulfilled.
+func (c *ResourceSyncController) SyncSecretConditionally(destination, source ResourceLocation, preconditionsFulfilledFn preconditionsFulfilled) error {
+	return c.syncSecret(destination, source, preconditionsFulfilledFn)
+}
+
+func (c *ResourceSyncController) syncSecret(destination, source ResourceLocation, preconditionsFulfilledFn preconditionsFulfilled, keys ...string) error {
+	if !c.knownNamespaces.Has(destination.Namespace) {
+		return fmt.Errorf("not watching namespace %q", destination.Namespace)
+	}
+	if source != emptyResourceLocation && !c.knownNamespaces.Has(source.Namespace) {
+		return fmt.Errorf("not watching namespace %q", source.Namespace)
+	}
+
+	c.syncRuleLock.Lock()
+	defer c.syncRuleLock.Unlock()
+	c.secretSyncRules[destination] = syncRuleSource{
+		ResourceLocation:         source,
+		syncedKeys:               sets.NewString(keys...),
+		preconditionsFulfilledFn: preconditionsFulfilledFn,
+	}
+
+	// make sure the new rule is picked up
+	c.syncCtx.Queue().Add(c.syncCtx.QueueKey())
+	return nil
+}
+
+// errorWithProvider provides a finger of blame in case a source resource cannot be retrieved.
+func errorWithProvider(provider string, err error) error {
+	if len(provider) > 0 {
+		return fmt.Errorf("%w (check the %q that is supposed to provide this resource)", err, provider)
+	}
+	return err
+}
+
+func (c *ResourceSyncController) Sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	operatorSpec, _, _, err := c.operatorConfigClient.GetOperatorState()
+	if err != nil {
+		return err
+	}
+
+	if !management.IsOperatorManaged(operatorSpec.ManagementState) {
+		return nil
+	}
+
+	c.syncRuleLock.RLock()
+	defer c.syncRuleLock.RUnlock()
+
+	errors := []error{}
+
+	for destination, source := range c.configMapSyncRules {
+		// skip the sync if the preconditions aren't fulfilled
+		if fulfilled, err := source.preconditionsFulfilledFn(); !fulfilled || err != nil {
+			if err != nil {
+				errors = append(errors, err)
+			}
+			continue
+		}
+
+		if source.ResourceLocation == emptyResourceLocation {
+			// use the cache to check whether the configmap exists in target namespace, if not skip the extra delete call.
+			if _, err := c.configMapGetter.ConfigMaps(destination.Namespace).Get(ctx, destination.Name, metav1.GetOptions{}); err != nil {
+				if !apierrors.IsNotFound(err) {
+					errors = append(errors, err)
+				}
+				continue
+			}
+			if err := c.configMapGetter.ConfigMaps(destination.Namespace).Delete(ctx, destination.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				errors = append(errors, err)
+			}
+			continue
+		}
+
+		_, _, err := resourceapply.SyncPartialConfigMap(ctx, c.configMapGetter, syncCtx.Recorder(), source.Namespace, source.Name, destination.Namespace, destination.Name, source.syncedKeys, []metav1.OwnerReference{})
+		if err != nil {
+			errors = append(errors, errorWithProvider(source.Provider, err))
+		}
+	}
+	for destination, source := range c.secretSyncRules {
+		// skip the sync if the preconditions aren't fulfilled
+		if fulfilled, err := source.preconditionsFulfilledFn(); !fulfilled || err != nil {
+			if err != nil {
+				errors = append(errors, err)
+			}
+			continue
+		}
+
+		if source.ResourceLocation == emptyResourceLocation {
+			// use the cache to check whether the secret exists in target namespace, if not skip the extra delete call.
+			if _, err := c.secretGetter.Secrets(destination.Namespace).Get(ctx, destination.Name, metav1.GetOptions{}); err != nil {
+				if !apierrors.IsNotFound(err) {
+					errors = append(errors, err)
+				}
+				continue
+			}
+			if err := c.secretGetter.Secrets(destination.Namespace).Delete(ctx, destination.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				errors = append(errors, err)
+			}
+			continue
+		}
+
+		_, _, err := resourceapply.SyncPartialSecret(ctx, c.secretGetter, syncCtx.Recorder(), source.Namespace, source.Name, destination.Namespace, destination.Name, source.syncedKeys, []metav1.OwnerReference{})
+		if err != nil {
+			errors = append(errors, errorWithProvider(source.Provider, err))
+		}
+	}
+
+	if len(errors) > 0 {
+		cond := operatorv1.OperatorCondition{
+			Type:    condition.ResourceSyncControllerDegradedConditionType,
+			Status:  operatorv1.ConditionTrue,
+			Reason:  "Error",
+			Message: v1helpers.NewMultiLineAggregate(errors).Error(),
+		}
+		if _, _, updateError := v1helpers.UpdateStatus(ctx, c.operatorConfigClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
+			return updateError
+		}
+		return nil
+	}
+
+	cond := operatorv1.OperatorCondition{
+		Type:   condition.ResourceSyncControllerDegradedConditionType,
+		Status: operatorv1.ConditionFalse,
+	}
+	if _, _, updateError := v1helpers.UpdateStatus(ctx, c.operatorConfigClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
+		return updateError
+	}
+	return nil
+}
+
+func NewDebugHandler(controller *ResourceSyncController) http.Handler {
+	return &debugHTTPHandler{controller: controller}
+}
+
+type debugHTTPHandler struct {
+	controller *ResourceSyncController
+}
+
+type ResourceSyncRule struct {
+	Destination ResourceLocation `json:"destination"`
+	Source      syncRuleSource   `json:"source"`
+}
+
+type ResourceSyncRuleList []ResourceSyncRule
+
+func (l ResourceSyncRuleList) Len() int      { return len(l) }
+func (l ResourceSyncRuleList) Swap(i, j int) { l[i], l[j] = l[j], l[i] }
+func (l ResourceSyncRuleList) Less(i, j int) bool {
+	if strings.Compare(l[i].Source.Namespace, l[j].Source.Namespace) < 0 {
+		return true
+	}
+	if strings.Compare(l[i].Source.Namespace, l[j].Source.Namespace) > 0 {
+		return false
+	}
+	if strings.Compare(l[i].Source.Name, l[j].Source.Name) < 0 {
+		return true
+	}
+	return false
+}
+
+type ControllerSyncRules struct {
+	Secrets ResourceSyncRuleList `json:"secrets"`
+	Configs ResourceSyncRuleList `json:"configs"`
+}
+
+// ServeSyncRules provides a handler function to return the sync rules of the controller
+func (h *debugHTTPHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	syncRules := ControllerSyncRules{ResourceSyncRuleList{}, ResourceSyncRuleList{}}
+
+	h.controller.syncRuleLock.RLock()
+	defer h.controller.syncRuleLock.RUnlock()
+	syncRules.Secrets = append(syncRules.Secrets, resourceSyncRuleList(h.controller.secretSyncRules)...)
+	syncRules.Configs = append(syncRules.Configs, resourceSyncRuleList(h.controller.configMapSyncRules)...)
+
+	data, err := json.Marshal(syncRules)
+	if err != nil {
+		w.Write([]byte(err.Error()))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.Write(data)
+	w.WriteHeader(http.StatusOK)
+}
+
+func resourceSyncRuleList(syncRules syncRules) ResourceSyncRuleList {
+	rules := make(ResourceSyncRuleList, 0, len(syncRules))
+	for dest, src := range syncRules {
+		rule := ResourceSyncRule{
+			Source:      src,
+			Destination: dest,
+		}
+		rules = append(rules, rule)
+	}
+	sort.Sort(rules)
+	return rules
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -239,6 +239,9 @@ github.com/openshift/library-go/pkg/controller/factory
 github.com/openshift/library-go/pkg/controller/fileobserver
 github.com/openshift/library-go/pkg/crypto
 github.com/openshift/library-go/pkg/network
+github.com/openshift/library-go/pkg/operator/condition
+github.com/openshift/library-go/pkg/operator/configobserver
+github.com/openshift/library-go/pkg/operator/configobserver/apiserver
 github.com/openshift/library-go/pkg/operator/events
 github.com/openshift/library-go/pkg/operator/loglevel
 github.com/openshift/library-go/pkg/operator/management
@@ -246,6 +249,7 @@ github.com/openshift/library-go/pkg/operator/resource/resourceapply
 github.com/openshift/library-go/pkg/operator/resource/resourcehelper
 github.com/openshift/library-go/pkg/operator/resource/resourcemerge
 github.com/openshift/library-go/pkg/operator/resource/resourceread
+github.com/openshift/library-go/pkg/operator/resourcesynccontroller
 github.com/openshift/library-go/pkg/operator/v1helpers
 github.com/openshift/library-go/pkg/serviceability
 # github.com/pkg/errors v0.9.1


### PR DESCRIPTION
To support cluster wide cryptographic policy as is done in KS, KA and KCM.

Originally reported in https://bugzilla.redhat.com/show_bug.cgi?id=1844989 and resolved as part of https://issues.redhat.com/browse/WRKLDS-241 for KS, KA and KCM

Following the same code changes as performed in https://github.com/openshift/cluster-kube-controller-manager-operator/pull/506.