### PR TITLE
bug 2041466: Dockerfile: use make build instead of go build

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,7 +1,7 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.10 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-kube-descheduler-operator
 COPY . .
-RUN go build -o cluster-kube-descheduler-operator ./cmd/cluster-kube-descheduler-operator
+RUN make build --warn-undefined-variables
 
 FROM registry.ci.openshift.org/ocp/4.10:base
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-descheduler-operator/cluster-kube-descheduler-operator /usr/bin/


### PR DESCRIPTION
`go build` does not take into account env variables populated by the building system. `make build` does by populating GO_LD_FLAGS env (see https://github.com/openshift/cluster-kube-descheduler-operator/blob/master/vendor/github.com/openshift/build-machinery-go/make/lib/golang.mk).