### PR TITLE
Bug 2042029: add missing permission for leases.coordination.k8s.io

### DIFF
--- a/manifests/4.10/cluster-kube-descheduler-operator.v4.10.0.clusterserviceversion.yaml
+++ b/manifests/4.10/cluster-kube-descheduler-operator.v4.10.0.clusterserviceversion.yaml
@@ -167,6 +167,12 @@ spec:
           - replicasets
           verbs:
           - "*"
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - "*"
       deployments:
       - name: descheduler-operator
         spec:


### PR DESCRIPTION
After switching to leases.coordination.k8s.io in dafe1bde7ad5aa7656dd7e087f068147a1d357d7
we need to ensure that there exists necessary permissions for it.

/assign @ingvagabund @ravisantoshgudimetla 