### PR TITLE
bug 2041326: Update the minKubeVersion in the CSV to reflect the v1.23 rebase

### DIFF
--- a/manifests/4.10/cluster-kube-descheduler-operator.v4.10.0.clusterserviceversion.yaml
+++ b/manifests/4.10/cluster-kube-descheduler-operator.v4.10.0.clusterserviceversion.yaml
@@ -87,7 +87,7 @@ spec:
   maintainers:
   - email: support@redhat.com
     name: Red Hat
-  minKubeVersion: 1.22.0
+  minKubeVersion: 1.23.0
   labels:
     olm-owner-enterprise-app: cluster-kube-descheduler-operator
     olm-status-descriptors: cluster-kube-descheduler-operator.v4.10.0


### PR DESCRIPTION
The operator kubernetes dependencies bumped in https://github.com/openshift/cluster-kube-descheduler-operator/pull/233.