### PR TITLE
bug 2042849: Dockerfile: use make build instead of go build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/openshift/cluster-kube-descheduler-operator
 COPY . .
 # image-references file is not recognized by OLM
 RUN rm manifests/4*/image-references
-RUN go build -o cluster-kube-descheduler-operator ./cmd/cluster-kube-descheduler-operator
+RUN make build --warn-undefined-variables
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-descheduler-operator/cluster-kube-descheduler-operator /usr/bin/

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,7 +1,7 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.9 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-kube-descheduler-operator
 COPY . .
-RUN go build -o cluster-kube-descheduler-operator ./cmd/cluster-kube-descheduler-operator
+RUN make build --warn-undefined-variables
 
 FROM registry.ci.openshift.org/ocp/4.9:base
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-descheduler-operator/cluster-kube-descheduler-operator /usr/bin/


### PR DESCRIPTION
go build does not take into account env variables populated by the
building system.
make build does by populating GO_LD_FLAGS env (see
https://github.com/openshift/cluster-kube-descheduler-operator/blob/master/vendor/github.com/openshift/build-machinery-go/make/lib/golang.mk).