### PR TITLE
Bug 2000653: Customize threshold priority params strategies wide, exclude hyperkube namespace

### DIFF
--- a/Dockerfile.metadata
+++ b/Dockerfile.metadata
@@ -1,0 +1,15 @@
+FROM registry.ci.openshift.org/openshift/release:golang-1.17 AS builder
+WORKDIR /go/src/github.com/openshift/cluster-kube-descheduler-operator
+COPY . .
+
+
+FROM registry.ci.openshift.org/openshift/origin-v4.0:base
+COPY --from=builder /go/src/github.com/openshift/cluster-kube-descheduler-operator/manifests/4.10 /manifests
+COPY --from=builder /go/src/github.com/openshift/cluster-kube-descheduler-operator/metadata /metadata
+RUN rm /manifests/image-references
+
+LABEL io.k8s.display-name="OpenShift Kube Descheduler Operator metadata" \
+      io.k8s.description="This is a component of OpenShift and manages the kube descheduler metadata" \
+      io.openshift.tags="openshift,cluster-kube-descheduler-operator,metadata" \
+      com.redhat.delivery.appregistry=true \
+      maintainer="AOS workloads team, <aos-workloads@redhat.com>"

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The following profiles are currently provided:
 * [`LifecycleAndUtilization`](#LifecycleAndUtilization)
 * [`EvictPodsWithPVC`](#EvictPodsWithPVC)
 * [`EvictPodsWithLocalStorage`](#EvictPodsWithLocalStorage)
-  
+
 Along with the following profiles, which are in development and may change:
 * [`DevPreviewLongLifecycle`](#DevPreviewLongLifecycle)
 
@@ -110,24 +110,24 @@ node is any node consuming more than 50% its available cpu, memory, *or* pod cap
 with less than 20% of its available cpu, memory, *and* pod capacity.
 
 This profile enables the [`LowNodeUtilizaition`](https://github.com/kubernetes-sigs/descheduler/#lownodeutilization),
-[`RemovePodsHavingTooManyRestarts`](https://github.com/kubernetes-sigs/descheduler/#removepodshavingtoomanyrestarts) and 
+[`RemovePodsHavingTooManyRestarts`](https://github.com/kubernetes-sigs/descheduler/#removepodshavingtoomanyrestarts) and
 [`PodLifeTime`](https://github.com/kubernetes-sigs/descheduler/#podlifetime) strategies. In the future, more configuration
 may be made available through the operator for these strategies based on user feedback.
 
 ### DevPreviewLongLifecycle
-This profile provides cluster resource balancing similar to [LifecycleAndUtilization](#LifecycleAndUtilization) for longer-running 
+This profile provides cluster resource balancing similar to [LifecycleAndUtilization](#LifecycleAndUtilization) for longer-running
 clusters. It does not evict pods based on the 24 hour lifetime used by LifecycleAndUtilization.
 
 ### EvictPodsWithPVC
-By default, the operator prevents pods with PVCs from being evicted. Enabling this 
-profile in combination with any of the above profiles allows pods with PVCs to be 
+By default, the operator prevents pods with PVCs from being evicted. Enabling this
+profile in combination with any of the above profiles allows pods with PVCs to be
 eligible for eviction.
 
 ### EvictPodsWithLocalStorage
 By default, pods with local storage are not eligible to be considered for eviction by any
-profile. Using this profile allows them to be evicted if necessary. A pod is defined as using 
-local storage if any of its volumes have `HostPath` or `EmptyDir` set (note that a pod that only 
-uses PVCs does not fit this definition, and will need the `EvictPodsWithPVC` profile instead. Pods 
+profile. Using this profile allows them to be evicted if necessary. A pod is defined as using
+local storage if any of its volumes have `HostPath` or `EmptyDir` set (note that a pod that only
+uses PVCs does not fit this definition, and will need the `EvictPodsWithPVC` profile instead. Pods
 that use both will need both profiles to be evicted).
 
 ## Profile Customizations
@@ -137,6 +137,8 @@ the `profileCustomizations` field:
 |Name|Type|Description|
 |---|---|---|
 |`podLifetime`|`time.Duration`|Sets the lifetime value for pods evicted by the `LifecycleAndUtilization` profile|
+|`thresholdPriorityClassName`|`string`|Sets the priority class threshold by name for all strategies|
+|`thresholdPriority`|`string`|Sets the priority class threshold by value for all strategies|
 
 ## How does the descheduler operator work?
 

--- a/manifests/4.10/kube-descheduler-operator.crd.yaml
+++ b/manifests/4.10/kube-descheduler-operator.crd.yaml
@@ -70,6 +70,13 @@ spec:
                       description: PodLifetime is the length of time after which pods should be evicted This field should be used with profiles that enable the PodLifetime strategy, such as LifecycleAndUtilization
                       type: string
                       format: duration
+                    thresholdPriority:
+                      description: ThresholdPriority when set will reject eviction of any pod with priority equal or higher It is invalid to set it alongside ThresholdPriorityClassName
+                      type: integer
+                      format: int32
+                    thresholdPriorityClassName:
+                      description: ThresholdPriorityClassName when set will reject eviction of any pod with priority equal or higher It is invalid to set it alongside ThresholdPriority
+                      type: string
                 profiles:
                   description: Profiles sets which descheduler strategy profiles are enabled
                   type: array

--- a/pkg/apis/descheduler/v1/types_descheduler.go
+++ b/pkg/apis/descheduler/v1/types_descheduler.go
@@ -45,6 +45,14 @@ type ProfileCustomizations struct {
 	// This field should be used with profiles that enable the PodLifetime strategy, such as LifecycleAndUtilization
 	// +kubebuilder:validation:Format=duration
 	PodLifetime *metav1.Duration `json:"podLifetime,omitempty"`
+
+	// ThresholdPriority when set will reject eviction of any pod with priority equal or higher
+	// It is invalid to set it alongside ThresholdPriorityClassName
+	ThresholdPriority *int32 `json:"thresholdPriority,omitempty"`
+
+	// ThresholdPriorityClassName when set will reject eviction of any pod with priority equal or higher
+	// It is invalid to set it alongside ThresholdPriority
+	ThresholdPriorityClassName string `json:"thresholdPriorityClassName,omitempty"`
 }
 
 // DeschedulerProfile allows configuring the enabled strategy profiles for the descheduler

--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -80,7 +80,7 @@ func NewTargetConfigReconciler(
 		klog.ErrorS(err, "error listing namespaces")
 		return nil
 	}
-	excludedNamespaces := []string{"kube-system"}
+	excludedNamespaces := []string{"kube-system", "hypershift"}
 	for _, ns := range allNamespaces.Items {
 		if strings.HasPrefix(ns.Name, "openshift-") {
 			excludedNamespaces = append(excludedNamespaces, ns.Name)

--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -294,11 +294,33 @@ func (c *TargetConfigReconciler) manageConfigMap(descheduler *deschedulerv1.Kube
 		return nil, true, fmt.Errorf("enabling Descheduler LowNodeUtilization with Scheduler HighNodeUtilization may cause an eviction/scheduling hot loop")
 	}
 
-	// set PodLifetime if non-default
-	if descheduler.Spec.ProfileCustomizations != nil && descheduler.Spec.ProfileCustomizations.PodLifetime != nil {
-		seconds := uint(descheduler.Spec.ProfileCustomizations.PodLifetime.Seconds())
-		if _, ok := policy.Strategies["PodLifeTime"]; ok {
-			policy.Strategies["PodLifeTime"].Params.PodLifeTime.MaxPodLifeTimeSeconds = &seconds
+	if descheduler.Spec.ProfileCustomizations != nil {
+		// set PodLifetime if non-default
+		if descheduler.Spec.ProfileCustomizations.PodLifetime != nil {
+			seconds := uint(descheduler.Spec.ProfileCustomizations.PodLifetime.Seconds())
+			if _, ok := policy.Strategies["PodLifeTime"]; ok {
+				policy.Strategies["PodLifeTime"].Params.PodLifeTime.MaxPodLifeTimeSeconds = &seconds
+			}
+		}
+
+		// set priority class threshold if customized
+		if descheduler.Spec.ProfileCustomizations.ThresholdPriority != nil && descheduler.Spec.ProfileCustomizations.ThresholdPriorityClassName != "" {
+			return nil, false, fmt.Errorf("It is invalid to set both .spec.profileCustomizations.thresholdPriority and .spec.profileCustomizations.ThresholdPriorityClassName fields")
+		}
+
+		if descheduler.Spec.ProfileCustomizations.ThresholdPriority != nil || descheduler.Spec.ProfileCustomizations.ThresholdPriorityClassName != "" {
+			for name, strategy := range policy.Strategies {
+				if strategy.Params == nil {
+					strategy.Params = &deschedulerapi.StrategyParameters{}
+				}
+				if descheduler.Spec.ProfileCustomizations.ThresholdPriority != nil {
+					priority := *descheduler.Spec.ProfileCustomizations.ThresholdPriority
+					policy.Strategies[name].Params.ThresholdPriority = &priority
+				}
+				if descheduler.Spec.ProfileCustomizations.ThresholdPriorityClassName != "" {
+					policy.Strategies[name].Params.ThresholdPriorityClassName = descheduler.Spec.ProfileCustomizations.ThresholdPriorityClassName
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Supersedes https://github.com/openshift/cluster-kube-descheduler-operator/pull/218

- add hypershift to list of default excluded namespaces (https://bugzilla.redhat.com/show_bug.cgi?id=2000653)
- customize threshold priority params strategies wide (https://issues.redhat.com/browse/WRKLDS-303)