### PR TITLE
bug 1991938: Add missing rbac

### DIFF
--- a/deploy/02_clusterrole.yaml
+++ b/deploy/02_clusterrole.yaml
@@ -56,3 +56,15 @@ rules:
   - replicasets
   verbs:
   - "*"
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - "customresourcedefinitions"
+  verbs:
+  - "*"
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions/status
+  verbs:
+  - update

--- a/manifests/4.8/cluster-kube-descheduler-operator.v4.8.0.clusterserviceversion.yaml
+++ b/manifests/4.8/cluster-kube-descheduler-operator.v4.8.0.clusterserviceversion.yaml
@@ -164,6 +164,12 @@ spec:
           - "customresourcedefinitions"
           verbs:
           - "*"
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions/status
+          verbs:
+          - update
       deployments:
       - name: descheduler-operator
         spec:


### PR DESCRIPTION
Add missing RBAC rule for updating kubedeschedulers.operator.openshift.io CRD status
```
E0316 15:26:00.119302       1 target_config_reconciler.go:425] key failed with : customresourcedefinitions.apiextensions.k8s.io "kubedeschedulers.operator.openshift.io" is forbidden: User "system:serviceaccount:openshift-kube-descheduler-operator:openshift-descheduler" cannot update resource "customresourcedefinitions/status" in API group "apiextensions.k8s.io" at the cluster scope
```