### PR TITLE
Fix kube-descheduler operator CRD link

### DIFF
--- a/deploy/0000_00_kube-descheduler-operator.crd.yaml
+++ b/deploy/0000_00_kube-descheduler-operator.crd.yaml
@@ -1,1 +1,1 @@
-../manifests/4.10/kube-descheduler-operator.crd.yaml
+../manifests/4.11/kube-descheduler-operator.crd.yaml


### PR DESCRIPTION
This was missed in #245
/assign @ingvagabund 