### PR TITLE
bug 2072911: Provide missing SA file

### DIFF
--- a/bindata/assets/kube-descheduler/operandserviceaccount.yaml
+++ b/bindata/assets/kube-descheduler/operandserviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openshift-descheduler-operand
+  namespace: openshift-kube-descheduler-operator


### PR DESCRIPTION
```
E0407 09:07:47.029627       1 runtime.go:78] Observed a panic: &fs.PathError{Op:"open", Path:"assets/kube-descheduler/operandserviceaccount.yaml", Err:(*errors.errorString)(0xc00007c040)} (open assets/kube-descheduler/operandserviceaccount.yaml: file does not exist)
goroutine 345 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x20a47c0, 0xc0008b7410})
	k8s.io/[apimachinery@v0.23.0](mailto:apimachinery@v0.23.0)/pkg/util/runtime/runtime.go:74 +0x7d
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x26bba90})
	k8s.io/[apimachinery@v0.23.0](mailto:apimachinery@v0.23.0)/pkg/util/runtime/runtime.go:48 +0x75
panic({0x20a47c0, 0xc0008b7410})
	runtime/panic.go:1038 +0x215
github.com/openshift/cluster-kube-descheduler-operator/bindata.MustAsset(...)
	github.com/openshift/cluster-kube-descheduler-operator/bindata/assets.go:20
github.com/openshift/cluster-kube-descheduler-operator/pkg/operator.(*TargetConfigReconciler).manageServiceAccount(0xc000729c98, 0xc000c32b40)
	github.com/openshift/cluster-kube-descheduler-operator/pkg/operator/target_config_reconciler.go:255 +0x1c7
github.com/openshift/cluster-kube-descheduler-operator/pkg/operator.TargetConfigReconciler.sync({{0x2717850, 0xc000614280}, {0xc00005c006, 0x75}, {0x26ed990, 0xc00093c6a0}, 0xc0009277d0, {0x2781fc8, 0xc00073ca80}, {0x26cc180, ...}, ...})
	github.com/openshift/cluster-kube-descheduler-operator/pkg/operator/target_config_reconciler.go:155 +0x30f
github.com/openshift/cluster-kube-descheduler-operator/pkg/operator.(*TargetConfigReconciler).processNextWorkItem(0xc000a781e0)
	github.com/openshift/cluster-kube-descheduler-operator/pkg/operator/target_config_reconciler.go:534 +0x138
github.com/openshift/cluster-kube-descheduler-operator/pkg/operator.(*TargetConfigReconciler).runWorker(...)
	github.com/openshift/cluster-kube-descheduler-operator/pkg/operator/target_config_reconciler.go:523
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc000d71f00)
	k8s.io/[apimachinery@v0.23.0](mailto:apimachinery@v0.23.0)/pkg/util/wait/wait.go:155 +0x67
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc00052bae8, {0x26cbcc0, 0xc0009fc1b0}, 0x1, 0xc0009a38c0)
	k8s.io/[apimachinery@v0.23.0](mailto:apimachinery@v0.23.0)/pkg/util/wait/wait.go:156 +0xb6
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x19260, 0x3b9aca00, 0x0, 0xe8, 0x445705)
	k8s.io/[apimachinery@v0.23.0](mailto:apimachinery@v0.23.0)/pkg/util/wait/wait.go:133 +0x89
k8s.io/apimachinery/pkg/util/wait.Until(0x9c2720, 0xc0004be010, 0xc0009497b8)
	k8s.io/[apimachinery@v0.23.0](mailto:apimachinery@v0.23.0)/pkg/util/wait/wait.go:90 +0x25
created by github.com/openshift/cluster-kube-descheduler-operator/pkg/operator.(*TargetConfigReconciler).Run
	github.com/openshift/cluster-kube-descheduler-operator/pkg/operator/target_config_reconciler.go:517 +0x225
I0407 09:07:47.029686       1 event.go:285] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-descheduler-operator", Name:"descheduler-operator", UID:"e1dc3943-acec-485c-ab91-c88cfec0991b", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'ServiceUpdated' Updated Service/metrics -n openshift-kube-descheduler-operator because it changed
I0407 09:07:47.029703       1 event.go:285] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-descheduler-operator", Name:"descheduler-operator", UID:"e1dc3943-acec-485c-ab91-c88cfec0991b", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'Openshift-Cluster-Kube-Descheduler-OperatorPanic' Panic observed: open assets/kube-descheduler/operandserviceaccount.yaml: file does not exist
E0407 09:07:48.588071       1 runtime.go:78] Observed a panic: &fs.PathError{Op:"open", Path:"assets/kube-descheduler/operandserviceaccount.yaml", Err:(*errors.errorString)(0xc00007c040)} (open assets/kube-descheduler/operandserviceaccount.yaml: file does not exist)
```