### PR TITLE
bug 2079805: [operator] manifests/deployment: comply to restricted pod security level

### DIFF
--- a/manifests/4.11/cluster-kube-descheduler-operator.v4.11.0.clusterserviceversion.yaml
+++ b/manifests/4.11/cluster-kube-descheduler-operator.v4.11.0.clusterserviceversion.yaml
@@ -202,8 +202,16 @@ spec:
               labels:
                 name: descheduler-operator
             spec:
+              securityContext:
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
               containers:
                 - name: descheduler-operator
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop: ["ALL"]
                   image: quay.io/openshift/origin-cluster-kube-descheduler-operator:4.11
                   resources:
                     requests:


### PR DESCRIPTION
Mirroring https://github.com/openshift/cluster-kube-scheduler-operator/pull/421

Follow up for https://github.com/openshift/cluster-kube-descheduler-operator/pull/257. Applying the change in the operator deployment as well.