### PR TITLE
bug 2093783: bump minKubeVersion to 1.24

### DIFF
--- a/manifests/4.11/cluster-kube-descheduler-operator.v4.11.0.clusterserviceversion.yaml
+++ b/manifests/4.11/cluster-kube-descheduler-operator.v4.11.0.clusterserviceversion.yaml
@@ -89,7 +89,7 @@ spec:
   maintainers:
   - email: support@redhat.com
     name: Red Hat
-  minKubeVersion: 1.23.0
+  minKubeVersion: 1.24.0
   labels:
     olm-owner-enterprise-app: cluster-kube-descheduler-operator
     olm-status-descriptors: cluster-kube-descheduler-operator.v4.11.0


### PR DESCRIPTION
Reference BZ 2093783. Bumping minKubeVersion on manifests/4.11/cluster-kube-descheduler-operator.v4.11.0.clusterserviceversion.yaml

Is anything else needed here? :)