### PR TITLE
bug 1957012: set ownerReference correctly

### DIFF
--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
+	"github.com/openshift/library-go/pkg/controller"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	v1 "k8s.io/api/core/v1"
@@ -195,28 +196,32 @@ func (c TargetConfigReconciler) sync() error {
 
 func (c *TargetConfigReconciler) manageClusterRole(descheduler *deschedulerv1.KubeDescheduler) (*rbacv1.ClusterRole, bool, error) {
 	required := resourceread.ReadClusterRoleV1OrDie(bindata.MustAsset("assets/kube-descheduler/operandclusterrole.yaml"))
-	required.OwnerReferences = []metav1.OwnerReference{
-		{
-			APIVersion: "v1",
-			Kind:       "KubeDescheduler",
-			Name:       descheduler.Name,
-			UID:        descheduler.UID,
-		},
+	ownerReference := metav1.OwnerReference{
+		APIVersion: "operator.openshift.io/v1",
+		Kind:       "KubeDescheduler",
+		Name:       descheduler.Name,
+		UID:        descheduler.UID,
 	}
+	required.OwnerReferences = []metav1.OwnerReference{
+		ownerReference,
+	}
+	controller.EnsureOwnerRef(required, ownerReference)
 
 	return resourceapply.ApplyClusterRole(c.ctx, c.kubeClient.RbacV1(), c.eventRecorder, required)
 }
 
 func (c *TargetConfigReconciler) manageClusterRoleBinding(descheduler *deschedulerv1.KubeDescheduler) (*rbacv1.ClusterRoleBinding, bool, error) {
 	required := resourceread.ReadClusterRoleBindingV1OrDie(bindata.MustAsset("assets/kube-descheduler/operandclusterrolebinding.yaml"))
-	required.OwnerReferences = []metav1.OwnerReference{
-		{
-			APIVersion: "v1",
-			Kind:       "KubeDescheduler",
-			Name:       descheduler.Name,
-			UID:        descheduler.UID,
-		},
+	ownerReference := metav1.OwnerReference{
+		APIVersion: "operator.openshift.io/v1",
+		Kind:       "KubeDescheduler",
+		Name:       descheduler.Name,
+		UID:        descheduler.UID,
 	}
+	required.OwnerReferences = []metav1.OwnerReference{
+		ownerReference,
+	}
+	controller.EnsureOwnerRef(required, ownerReference)
 
 	return resourceapply.ApplyClusterRoleBinding(c.ctx, c.kubeClient.RbacV1(), c.eventRecorder, required)
 }
@@ -224,14 +229,16 @@ func (c *TargetConfigReconciler) manageClusterRoleBinding(descheduler *deschedul
 func (c *TargetConfigReconciler) manageRole(descheduler *deschedulerv1.KubeDescheduler) (*rbacv1.Role, bool, error) {
 	required := resourceread.ReadRoleV1OrDie(bindata.MustAsset("assets/kube-descheduler/role.yaml"))
 	required.Namespace = descheduler.Namespace
-	required.OwnerReferences = []metav1.OwnerReference{
-		{
-			APIVersion: "v1",
-			Kind:       "KubeDescheduler",
-			Name:       descheduler.Name,
-			UID:        descheduler.UID,
-		},
+	ownerReference := metav1.OwnerReference{
+		APIVersion: "operator.openshift.io/v1",
+		Kind:       "KubeDescheduler",
+		Name:       descheduler.Name,
+		UID:        descheduler.UID,
 	}
+	required.OwnerReferences = []metav1.OwnerReference{
+		ownerReference,
+	}
+	controller.EnsureOwnerRef(required, ownerReference)
 
 	return resourceapply.ApplyRole(c.ctx, c.kubeClient.RbacV1(), c.eventRecorder, required)
 }
@@ -239,14 +246,16 @@ func (c *TargetConfigReconciler) manageRole(descheduler *deschedulerv1.KubeDesch
 func (c *TargetConfigReconciler) manageRoleBinding(descheduler *deschedulerv1.KubeDescheduler) (*rbacv1.RoleBinding, bool, error) {
 	required := resourceread.ReadRoleBindingV1OrDie(bindata.MustAsset("assets/kube-descheduler/rolebinding.yaml"))
 	required.Namespace = descheduler.Namespace
-	required.OwnerReferences = []metav1.OwnerReference{
-		{
-			APIVersion: "v1",
-			Kind:       "KubeDescheduler",
-			Name:       descheduler.Name,
-			UID:        descheduler.UID,
-		},
+	ownerReference := metav1.OwnerReference{
+		APIVersion: "operator.openshift.io/v1",
+		Kind:       "KubeDescheduler",
+		Name:       descheduler.Name,
+		UID:        descheduler.UID,
 	}
+	required.OwnerReferences = []metav1.OwnerReference{
+		ownerReference,
+	}
+	controller.EnsureOwnerRef(required, ownerReference)
 
 	return resourceapply.ApplyRoleBinding(c.ctx, c.kubeClient.RbacV1(), c.eventRecorder, required)
 }
@@ -254,14 +263,16 @@ func (c *TargetConfigReconciler) manageRoleBinding(descheduler *deschedulerv1.Ku
 func (c *TargetConfigReconciler) manageServiceAccount(descheduler *deschedulerv1.KubeDescheduler) (*v1.ServiceAccount, bool, error) {
 	required := resourceread.ReadServiceAccountV1OrDie(bindata.MustAsset("assets/kube-descheduler/operandserviceaccount.yaml"))
 	required.Namespace = descheduler.Namespace
-	required.OwnerReferences = []metav1.OwnerReference{
-		{
-			APIVersion: "v1",
-			Kind:       "KubeDescheduler",
-			Name:       descheduler.Name,
-			UID:        descheduler.UID,
-		},
+	ownerReference := metav1.OwnerReference{
+		APIVersion: "operator.openshift.io/v1",
+		Kind:       "KubeDescheduler",
+		Name:       descheduler.Name,
+		UID:        descheduler.UID,
 	}
+	required.OwnerReferences = []metav1.OwnerReference{
+		ownerReference,
+	}
+	controller.EnsureOwnerRef(required, ownerReference)
 
 	return resourceapply.ApplyServiceAccount(c.ctx, c.kubeClient.CoreV1(), c.eventRecorder, required)
 }
@@ -269,14 +280,16 @@ func (c *TargetConfigReconciler) manageServiceAccount(descheduler *deschedulerv1
 func (c *TargetConfigReconciler) manageService(descheduler *deschedulerv1.KubeDescheduler) (*v1.Service, bool, error) {
 	required := resourceread.ReadServiceV1OrDie(bindata.MustAsset("assets/kube-descheduler/service.yaml"))
 	required.Namespace = descheduler.Namespace
-	required.OwnerReferences = []metav1.OwnerReference{
-		{
-			APIVersion: "v1",
-			Kind:       "KubeDescheduler",
-			Name:       descheduler.Name,
-			UID:        descheduler.UID,
-		},
+	ownerReference := metav1.OwnerReference{
+		APIVersion: "operator.openshift.io/v1",
+		Kind:       "KubeDescheduler",
+		Name:       descheduler.Name,
+		UID:        descheduler.UID,
 	}
+	required.OwnerReferences = []metav1.OwnerReference{
+		ownerReference,
+	}
+	controller.EnsureOwnerRef(required, ownerReference)
 
 	return resourceapply.ApplyService(c.ctx, c.kubeClient.CoreV1(), c.eventRecorder, required)
 }
@@ -291,14 +304,16 @@ func (c *TargetConfigReconciler) manageConfigMap(descheduler *deschedulerv1.Kube
 	required := resourceread.ReadConfigMapV1OrDie(bindata.MustAsset("assets/kube-descheduler/configmap.yaml"))
 	required.Name = descheduler.Name
 	required.Namespace = descheduler.Namespace
-	required.OwnerReferences = []metav1.OwnerReference{
-		{
-			APIVersion: "v1",
-			Kind:       "KubeDescheduler",
-			Name:       descheduler.Name,
-			UID:        descheduler.UID,
-		},
+	ownerReference := metav1.OwnerReference{
+		APIVersion: "operator.openshift.io/v1",
+		Kind:       "KubeDescheduler",
+		Name:       descheduler.Name,
+		UID:        descheduler.UID,
 	}
+	required.OwnerReferences = []metav1.OwnerReference{
+		ownerReference,
+	}
+	controller.EnsureOwnerRef(required, ownerReference)
 
 	scheduler, err := c.configSchedulerLister.Get("cluster")
 	if err != nil {
@@ -483,14 +498,16 @@ func (c *TargetConfigReconciler) manageDeployment(descheduler *deschedulerv1.Kub
 	required := resourceread.ReadDeploymentV1OrDie(bindata.MustAsset("assets/kube-descheduler/deployment.yaml"))
 	required.Name = operatorclient.OperandName
 	required.Namespace = descheduler.Namespace
-	required.OwnerReferences = []metav1.OwnerReference{
-		{
-			APIVersion: "v1",
-			Kind:       "KubeDescheduler",
-			Name:       descheduler.Name,
-			UID:        descheduler.UID,
-		},
+	ownerReference := metav1.OwnerReference{
+		APIVersion: "operator.openshift.io/v1",
+		Kind:       "KubeDescheduler",
+		Name:       descheduler.Name,
+		UID:        descheduler.UID,
 	}
+	required.OwnerReferences = []metav1.OwnerReference{
+		ownerReference,
+	}
+	controller.EnsureOwnerRef(required, ownerReference)
 	replicas := int32(1)
 	required.Spec.Replicas = &replicas
 	required.Spec.Template.Spec.Containers[0].Args = append(required.Spec.Template.Spec.Containers[0].Args,

--- a/vendor/github.com/openshift/library-go/pkg/controller/ownerref.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/ownerref.go
@@ -1,0 +1,60 @@
+package controller
+
+import (
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// EnsureOwnerRef adds the ownerref if needed. Removes ownerrefs with conflicting UIDs.
+// Returns true if the input is mutated.
+func EnsureOwnerRef(metadata metav1.Object, newOwnerRef metav1.OwnerReference) bool {
+	foundButNotEqual := false
+	for _, existingOwnerRef := range metadata.GetOwnerReferences() {
+		if existingOwnerRef.APIVersion == newOwnerRef.APIVersion &&
+			existingOwnerRef.Kind == newOwnerRef.Kind &&
+			existingOwnerRef.Name == newOwnerRef.Name {
+
+			// if we're completely the same, there's nothing to do
+			if equality.Semantic.DeepEqual(existingOwnerRef, newOwnerRef) {
+				return false
+			}
+
+			foundButNotEqual = true
+			break
+		}
+	}
+
+	// if we weren't found, then we just need to add ourselves
+	if !foundButNotEqual {
+		metadata.SetOwnerReferences(append(metadata.GetOwnerReferences(), newOwnerRef))
+		return true
+	}
+
+	// if we need to remove an existing ownerRef, just do the easy thing and build it back from scratch
+	newOwnerRefs := []metav1.OwnerReference{newOwnerRef}
+	for i := range metadata.GetOwnerReferences() {
+		existingOwnerRef := metadata.GetOwnerReferences()[i]
+		if existingOwnerRef.APIVersion == newOwnerRef.APIVersion &&
+			existingOwnerRef.Kind == newOwnerRef.Kind &&
+			existingOwnerRef.Name == newOwnerRef.Name {
+			continue
+		}
+		newOwnerRefs = append(newOwnerRefs, existingOwnerRef)
+	}
+	metadata.SetOwnerReferences(newOwnerRefs)
+	return true
+}
+
+// HasOwnerRef checks to see if an object has a particular owner.  It is not opinionated about
+// the bool fields
+func HasOwnerRef(metadata metav1.Object, needle metav1.OwnerReference) bool {
+	for _, existingOwnerRef := range metadata.GetOwnerReferences() {
+		if existingOwnerRef.APIVersion == needle.APIVersion &&
+			existingOwnerRef.Kind == needle.Kind &&
+			existingOwnerRef.Name == needle.Name &&
+			existingOwnerRef.UID == needle.UID {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -236,6 +236,7 @@ github.com/openshift/library-go/pkg/config/clusterstatus
 github.com/openshift/library-go/pkg/config/configdefaults
 github.com/openshift/library-go/pkg/config/leaderelection
 github.com/openshift/library-go/pkg/config/serving
+github.com/openshift/library-go/pkg/controller
 github.com/openshift/library-go/pkg/controller/controllercmd
 github.com/openshift/library-go/pkg/controller/factory
 github.com/openshift/library-go/pkg/controller/fileobserver


### PR DESCRIPTION
- [x] APIVersion should contain group + version
- [x] we should use EnsureOwnerRef just in case there are any problems with UIDs

The BZ is for an older version of Openshift, I am still not familiar with backporting stuff, so I will need help there.

~Also, I got a bunch of changes coming from go mod vendor and go mod tidy, not sure those should come here.~ (seems to be ok now)