### PR TITLE
Enable descheduler for arm64

### DIFF
--- a/manifests/4.12/cluster-kube-descheduler-operator.v4.12.0.clusterserviceversion.yaml
+++ b/manifests/4.12/cluster-kube-descheduler-operator.v4.12.0.clusterserviceversion.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: openshift-kube-descheduler-operator
   labels:
     operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
   annotations:


### PR DESCRIPTION
Adds arm64 support to operator hub.

ARM QE validated descheduler for arm64 
cc: @aleskandro @andymcc 