### PR TITLE
OCPBUGS-2330: add new events apiGroup

### DIFF
--- a/bindata/assets/kube-descheduler/operandclusterrole.yaml
+++ b/bindata/assets/kube-descheduler/operandclusterrole.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openshift-descheduler-operand
 rules:
 - apiGroups:
-  - ""
+  - "events.k8s.io"
   resources:
   - "events"
   verbs:


### PR DESCRIPTION
descheduler is using the new events api, and we need to update rbac to align with it