### PR TITLE
Duplicate logging level specified in the generated Pod

### DIFF
--- a/bindata/assets/kube-descheduler/deployment.yaml
+++ b/bindata/assets/kube-descheduler/deployment.yaml
@@ -47,7 +47,6 @@ spec:
           command: ["/bin/descheduler"]
           args:
             - --policy-config-file=/policy-dir/policy.yaml
-            - --v=2
             - --logging-format=text
             - --tls-cert-file=/certs-dir/tls.crt
             - --tls-private-key-file=/certs-dir/tls.key


### PR DESCRIPTION
# Duplicate logging level specified in the generated Pod

The binary asset deployment.yaml specifys the `--v=2` to set the logging level. 

In the Operator's pod, I noticed this:

```
spec:
  containers:
  - args:
    - --policy-config-file=/policy-dir/policy.yaml
    - --v=2
    - --logging-format=text
    - --tls-cert-file=/certs-dir/tls.crt
    - --tls-private-key-file=/certs-dir/tls.key
    - --descheduling-interval=60s
    - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
    - --tls-min-version=VersionTLS12
    - -v=8
```

This is due to [source](https://github.com/openshift/cluster-kube-descheduler-operator/blob/master/pkg/operator/target_config_reconciler.go#L608)  Line 608 in the target_config_reconciler.go

It's such a small change, I err'd on the side of not opening a bug. 

Signed-off-by: Paul Bastide <pbastide@redhat.com>