### PR TITLE
fix naming convention

### DIFF
--- a/manifests/art.yaml
+++ b/manifests/art.yaml
@@ -3,7 +3,7 @@ updates:
     update_list:
     # replace metadata.name value
     - search: "clusterkubedescheduleroperator.v{MAJOR}.{MINOR}.0"
-      replace: "clusterkubedescheduleroperator.{FULL_VER}"
+      replace: "clusterkubedescheduleroperator.v{FULL_VER}"
     # replace entire version line, otherwise would replace {MAJOR}.{MINOR}.0 anywhere
     - search: "version: {MAJOR}.{MINOR}.0"
       replace: "version: {FULL_VER}"


### PR DESCRIPTION
there is a warning reported in CVP check for 4.12
`Warning: Value : (clusterkubedescheduleroperator.4.12.0-202211081106) csv.metadata.Name clusterkubedescheduleroperator.4.12.0-202211081106 is not following the recommended naming convention: <operator-name>.v<semver> e.g. memcached-operator.v0.0.1`
http://external-ci-coldstorage.datahub.redhat.com/cvp/cvp-redhat-operator-bundle-image-validation-test/ose-cluster-kube-descheduler-operator-metadata-container-v4.12.0.202211081106.p0.gda308c7.assembly.stream-1/c157c77d-73e2-4b6f-b59c-be1dbe0dbab7/operator-metadata-linting-bundle-image-output.txt
I think this could be a common issue, so pr against master can cherry-pick to 4.12 branch later.