### PR TITLE
Allow ns exclusion, error on inclusion for nodeutilization

### DIFF
--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -412,62 +412,67 @@ func (c *TargetConfigReconciler) manageConfigMap(descheduler *deschedulerv1.Kube
 			if strategy.Params == nil {
 				strategy.Params = &deschedulerapi.StrategyParameters{}
 			}
-			if descheduler.Spec.ProfileCustomizations != nil && descheduler.Spec.ProfileCustomizations.DevLowNodeUtilizationThresholds != nil {
-				if strategy.Params == nil {
-					strategy.Params = &deschedulerapi.StrategyParameters{}
+			if name == "LowNodeUtilization" {
+				if len(includedNamespaces) > 0 {
+					return nil, false, fmt.Errorf("only namespace exclusion supported with LowNodeUtilization")
 				}
-				switch *descheduler.Spec.ProfileCustomizations.DevLowNodeUtilizationThresholds {
-				case deschedulerv1.LowThreshold:
-					strategy.Params.NodeResourceUtilizationThresholds = &deschedulerapi.NodeResourceUtilizationThresholds{
-						Thresholds: map[v1.ResourceName]deschedulerapi.Percentage{
-							"cpu":    10,
-							"memory": 10,
-							"pods":   10,
-						},
-						TargetThresholds: map[v1.ResourceName]deschedulerapi.Percentage{
-							"cpu":    30,
-							"memory": 30,
-							"pods":   30,
-						},
-					}
-				case deschedulerv1.MediumThreshold:
-					strategy.Params.NodeResourceUtilizationThresholds = &deschedulerapi.NodeResourceUtilizationThresholds{
-						Thresholds: map[v1.ResourceName]deschedulerapi.Percentage{
-							"cpu":    20,
-							"memory": 20,
-							"pods":   20,
-						},
-						TargetThresholds: map[v1.ResourceName]deschedulerapi.Percentage{
-							"cpu":    50,
-							"memory": 50,
-							"pods":   50,
-						},
-					}
-				case deschedulerv1.HighThreshold:
-					strategy.Params.NodeResourceUtilizationThresholds = &deschedulerapi.NodeResourceUtilizationThresholds{
-						Thresholds: map[v1.ResourceName]deschedulerapi.Percentage{
-							"cpu":    40,
-							"memory": 40,
-							"pods":   40,
-						},
-						TargetThresholds: map[v1.ResourceName]deschedulerapi.Percentage{
-							"cpu":    70,
-							"memory": 70,
-							"pods":   70,
-						},
-					}
-				default:
-					return nil, false, fmt.Errorf("unknown Descheduler LowNodeUtilization threshold %v, only 'Low', 'Medium' and 'High' are supported", *descheduler.Spec.ProfileCustomizations.DevLowNodeUtilizationThresholds)
-				}
-			}
-			if name == "LowNodeUtilization" && len(includedNamespaces) > 0 {
-				return nil, false, fmt.Errorf("only namespace exclusion supported with LowNodeUtilization")
 
+				if descheduler.Spec.ProfileCustomizations != nil && descheduler.Spec.ProfileCustomizations.DevLowNodeUtilizationThresholds != nil {
+					if strategy.Params == nil {
+						strategy.Params = &deschedulerapi.StrategyParameters{}
+					}
+					switch *descheduler.Spec.ProfileCustomizations.DevLowNodeUtilizationThresholds {
+					case deschedulerv1.LowThreshold:
+						strategy.Params.NodeResourceUtilizationThresholds = &deschedulerapi.NodeResourceUtilizationThresholds{
+							Thresholds: map[v1.ResourceName]deschedulerapi.Percentage{
+								"cpu":    10,
+								"memory": 10,
+								"pods":   10,
+							},
+							TargetThresholds: map[v1.ResourceName]deschedulerapi.Percentage{
+								"cpu":    30,
+								"memory": 30,
+								"pods":   30,
+							},
+						}
+					case deschedulerv1.MediumThreshold:
+						strategy.Params.NodeResourceUtilizationThresholds = &deschedulerapi.NodeResourceUtilizationThresholds{
+							Thresholds: map[v1.ResourceName]deschedulerapi.Percentage{
+								"cpu":    20,
+								"memory": 20,
+								"pods":   20,
+							},
+							TargetThresholds: map[v1.ResourceName]deschedulerapi.Percentage{
+								"cpu":    50,
+								"memory": 50,
+								"pods":   50,
+							},
+						}
+					case deschedulerv1.HighThreshold:
+						strategy.Params.NodeResourceUtilizationThresholds = &deschedulerapi.NodeResourceUtilizationThresholds{
+							Thresholds: map[v1.ResourceName]deschedulerapi.Percentage{
+								"cpu":    40,
+								"memory": 40,
+								"pods":   40,
+							},
+							TargetThresholds: map[v1.ResourceName]deschedulerapi.Percentage{
+								"cpu":    70,
+								"memory": 70,
+								"pods":   70,
+							},
+						}
+					default:
+						return nil, false, fmt.Errorf("unknown Descheduler LowNodeUtilization threshold %v, only 'Low', 'Medium' and 'High' are supported", *descheduler.Spec.ProfileCustomizations.DevLowNodeUtilizationThresholds)
+					}
+				}
 			}
-			strategy.Params.Namespaces = &deschedulerapi.Namespaces{
-				Exclude: excludedNamespaces,
-				Include: includedNamespaces,
+			if len(excludedNamespaces) > 0 || len(includedNamespaces) > 0 {
+				strategy.Params.Namespaces = &deschedulerapi.Namespaces{
+					Exclude: excludedNamespaces,
+					Include: includedNamespaces,
+				}
 			}
+
 			profile.Strategies[name] = strategy
 		}
 		mergo.Merge(policy, profile, mergo.WithAppendSlice, mergo.WithOverride)

--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -412,61 +412,61 @@ func (c *TargetConfigReconciler) manageConfigMap(descheduler *deschedulerv1.Kube
 			if strategy.Params == nil {
 				strategy.Params = &deschedulerapi.StrategyParameters{}
 			}
-			// skip strategies which don't support namespace exclusion yet
-			if name == "LowNodeUtilization" {
-				if descheduler.Spec.ProfileCustomizations != nil && descheduler.Spec.ProfileCustomizations.DevLowNodeUtilizationThresholds != nil {
-					if strategy.Params == nil {
-						strategy.Params = &deschedulerapi.StrategyParameters{}
-					}
-					switch *descheduler.Spec.ProfileCustomizations.DevLowNodeUtilizationThresholds {
-					case deschedulerv1.LowThreshold:
-						strategy.Params.NodeResourceUtilizationThresholds = &deschedulerapi.NodeResourceUtilizationThresholds{
-							Thresholds: map[v1.ResourceName]deschedulerapi.Percentage{
-								"cpu":    10,
-								"memory": 10,
-								"pods":   10,
-							},
-							TargetThresholds: map[v1.ResourceName]deschedulerapi.Percentage{
-								"cpu":    30,
-								"memory": 30,
-								"pods":   30,
-							},
-						}
-					case deschedulerv1.MediumThreshold:
-						strategy.Params.NodeResourceUtilizationThresholds = &deschedulerapi.NodeResourceUtilizationThresholds{
-							Thresholds: map[v1.ResourceName]deschedulerapi.Percentage{
-								"cpu":    20,
-								"memory": 20,
-								"pods":   20,
-							},
-							TargetThresholds: map[v1.ResourceName]deschedulerapi.Percentage{
-								"cpu":    50,
-								"memory": 50,
-								"pods":   50,
-							},
-						}
-					case deschedulerv1.HighThreshold:
-						strategy.Params.NodeResourceUtilizationThresholds = &deschedulerapi.NodeResourceUtilizationThresholds{
-							Thresholds: map[v1.ResourceName]deschedulerapi.Percentage{
-								"cpu":    40,
-								"memory": 40,
-								"pods":   40,
-							},
-							TargetThresholds: map[v1.ResourceName]deschedulerapi.Percentage{
-								"cpu":    70,
-								"memory": 70,
-								"pods":   70,
-							},
-						}
-					default:
-						return nil, false, fmt.Errorf("unknown Descheduler LowNodeUtilization threshold %v, only 'Low', 'Medium' and 'High' are supported", *descheduler.Spec.ProfileCustomizations.DevLowNodeUtilizationThresholds)
-					}
+			if descheduler.Spec.ProfileCustomizations != nil && descheduler.Spec.ProfileCustomizations.DevLowNodeUtilizationThresholds != nil {
+				if strategy.Params == nil {
+					strategy.Params = &deschedulerapi.StrategyParameters{}
 				}
-			} else {
-				strategy.Params.Namespaces = &deschedulerapi.Namespaces{
-					Exclude: excludedNamespaces,
-					Include: includedNamespaces,
+				switch *descheduler.Spec.ProfileCustomizations.DevLowNodeUtilizationThresholds {
+				case deschedulerv1.LowThreshold:
+					strategy.Params.NodeResourceUtilizationThresholds = &deschedulerapi.NodeResourceUtilizationThresholds{
+						Thresholds: map[v1.ResourceName]deschedulerapi.Percentage{
+							"cpu":    10,
+							"memory": 10,
+							"pods":   10,
+						},
+						TargetThresholds: map[v1.ResourceName]deschedulerapi.Percentage{
+							"cpu":    30,
+							"memory": 30,
+							"pods":   30,
+						},
+					}
+				case deschedulerv1.MediumThreshold:
+					strategy.Params.NodeResourceUtilizationThresholds = &deschedulerapi.NodeResourceUtilizationThresholds{
+						Thresholds: map[v1.ResourceName]deschedulerapi.Percentage{
+							"cpu":    20,
+							"memory": 20,
+							"pods":   20,
+						},
+						TargetThresholds: map[v1.ResourceName]deschedulerapi.Percentage{
+							"cpu":    50,
+							"memory": 50,
+							"pods":   50,
+						},
+					}
+				case deschedulerv1.HighThreshold:
+					strategy.Params.NodeResourceUtilizationThresholds = &deschedulerapi.NodeResourceUtilizationThresholds{
+						Thresholds: map[v1.ResourceName]deschedulerapi.Percentage{
+							"cpu":    40,
+							"memory": 40,
+							"pods":   40,
+						},
+						TargetThresholds: map[v1.ResourceName]deschedulerapi.Percentage{
+							"cpu":    70,
+							"memory": 70,
+							"pods":   70,
+						},
+					}
+				default:
+					return nil, false, fmt.Errorf("unknown Descheduler LowNodeUtilization threshold %v, only 'Low', 'Medium' and 'High' are supported", *descheduler.Spec.ProfileCustomizations.DevLowNodeUtilizationThresholds)
 				}
+			}
+			if name == "LowNodeUtilization" && len(includedNamespaces) > 0 {
+				return nil, false, fmt.Errorf("only namespace exclusion supported with LowNodeUtilization")
+
+			}
+			strategy.Params.Namespaces = &deschedulerapi.Namespaces{
+				Exclude: excludedNamespaces,
+				Include: includedNamespaces,
 			}
 			profile.Strategies[name] = strategy
 		}

--- a/pkg/operator/target_config_reconciler_test.go
+++ b/pkg/operator/target_config_reconciler_test.go
@@ -50,9 +50,7 @@ strategies:
       includePreferNoSchedule: false
       includeSoftConstraints: false
       labelSelector: null
-      namespaces:
-        exclude: null
-        include: []
+      namespaces: null
       nodeFit: false
       podLifeTime:
         maxPodLifeTimeSeconds: 300
@@ -64,9 +62,7 @@ strategies:
       includePreferNoSchedule: false
       includeSoftConstraints: false
       labelSelector: null
-      namespaces:
-        exclude: null
-        include: []
+      namespaces: null
       nodeFit: false
       podsHavingTooManyRestarts:
         includingInitContainers: true
@@ -104,9 +100,7 @@ strategies:
       includePreferNoSchedule: false
       includeSoftConstraints: false
       labelSelector: null
-      namespaces:
-        exclude: null
-        include: []
+      namespaces: null
       nodeFit: false
       podLifeTime:
         maxPodLifeTimeSeconds: 86400
@@ -118,9 +112,7 @@ strategies:
       includePreferNoSchedule: false
       includeSoftConstraints: false
       labelSelector: null
-      namespaces:
-        exclude: null
-        include: []
+      namespaces: null
       nodeFit: false
       podsHavingTooManyRestarts:
         includingInitContainers: true
@@ -158,9 +150,7 @@ strategies:
       includePreferNoSchedule: false
       includeSoftConstraints: false
       labelSelector: null
-      namespaces:
-        exclude: null
-        include: []
+      namespaces: null
       nodeFit: false
       podLifeTime:
         maxPodLifeTimeSeconds: 86400
@@ -172,9 +162,7 @@ strategies:
       includePreferNoSchedule: false
       includeSoftConstraints: false
       labelSelector: null
-      namespaces:
-        exclude: null
-        include: []
+      namespaces: null
       nodeFit: false
       podsHavingTooManyRestarts:
         includingInitContainers: true
@@ -212,9 +200,7 @@ strategies:
       includePreferNoSchedule: false
       includeSoftConstraints: false
       labelSelector: null
-      namespaces:
-        exclude: null
-        include: []
+      namespaces: null
       nodeFit: false
       podLifeTime:
         maxPodLifeTimeSeconds: 86400
@@ -226,9 +212,7 @@ strategies:
       includePreferNoSchedule: false
       includeSoftConstraints: false
       labelSelector: null
-      namespaces:
-        exclude: null
-        include: []
+      namespaces: null
       nodeFit: false
       podsHavingTooManyRestarts:
         includingInitContainers: true
@@ -266,9 +250,7 @@ strategies:
       includePreferNoSchedule: false
       includeSoftConstraints: false
       labelSelector: null
-      namespaces:
-        exclude: null
-        include: []
+      namespaces: null
       nodeFit: false
       podLifeTime:
         maxPodLifeTimeSeconds: 86400
@@ -280,9 +262,7 @@ strategies:
       includePreferNoSchedule: false
       includeSoftConstraints: false
       labelSelector: null
-      namespaces:
-        exclude: null
-        include: []
+      namespaces: null
       nodeFit: false
       podsHavingTooManyRestarts:
         includingInitContainers: true
@@ -320,9 +300,7 @@ strategies:
       includePreferNoSchedule: false
       includeSoftConstraints: false
       labelSelector: null
-      namespaces:
-        exclude: null
-        include: []
+      namespaces: null
       nodeFit: false
       podLifeTime:
         maxPodLifeTimeSeconds: 86400
@@ -334,9 +312,7 @@ strategies:
       includePreferNoSchedule: false
       includeSoftConstraints: false
       labelSelector: null
-      namespaces:
-        exclude: null
-        include: []
+      namespaces: null
       nodeFit: false
       podsHavingTooManyRestarts:
         includingInitContainers: true
@@ -374,9 +350,7 @@ strategies:
       includePreferNoSchedule: false
       includeSoftConstraints: false
       labelSelector: null
-      namespaces:
-        exclude: null
-        include: []
+      namespaces: null
       nodeFit: false
       podLifeTime:
         maxPodLifeTimeSeconds: 86400
@@ -388,9 +362,7 @@ strategies:
       includePreferNoSchedule: false
       includeSoftConstraints: false
       labelSelector: null
-      namespaces:
-        exclude: null
-        include: []
+      namespaces: null
       nodeFit: false
       podsHavingTooManyRestarts:
         includingInitContainers: true


### PR DESCRIPTION
This is possible starting on 4.13, https://github.com/kubernetes-sigs/descheduler/tree/93a014ef5ebe66d4945f5ad181deb5af9c61ccd8#namespace-filtering + https://github.com/kubernetes-sigs/descheduler/issues/1005 + https://issues.redhat.com/browse/OCPBUGS-513