### PR TITLE
OCPBUGS-1995: Drop descheduler operand resource limits

### DIFF
--- a/bindata/assets/kube-descheduler/deployment.yaml
+++ b/bindata/assets/kube-descheduler/deployment.yaml
@@ -38,9 +38,6 @@ spec:
               drop: ["ALL"]
           image: ${IMAGE}
           resources:
-            limits:
-              cpu: "100m"
-              memory: "500Mi"
             requests:
               cpu: "100m"
               memory: "500Mi"


### PR DESCRIPTION
With measurements provided from one of our descheduler contributors the memory consumption of the descheduler in a big cluster can grow over 1.5GB. The same observation holds for the kube-scheduler which has no resource limits defined. Comparing graphs of memory consuption of both the descheduler and the kube-scheduler shows a very similar pattern.