### PR TITLE
use `stable` channel in CSV

### DIFF
--- a/manifests/cluster-kube-descheduler-operator.package.yaml
+++ b/manifests/cluster-kube-descheduler-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: cluster-kube-descheduler-operator
 channels:
-- name: "4.14"
+- name: stable
   currentCSV: cluster-kube-descheduler-operator.v4.14.0


### PR DESCRIPTION
With 4.14, ART no longer forces a stable channel, but instead uses what you have here as the channel list. You probably want it to be `stable`.

reference [slack chat](https://redhat-internal.slack.com/archives/CB95J6R4N/p1694127434005319?thread_ts=1694094694.738739&cid=CB95J6R4N) and you'll want to backport this to 4.14 as well.