### PR TITLE
add flag to be able disable podLifetime

### DIFF
--- a/pkg/apis/descheduler/v1/types_descheduler.go
+++ b/pkg/apis/descheduler/v1/types_descheduler.go
@@ -46,6 +46,10 @@ type KubeDeschedulerSpec struct {
 
 // ProfileCustomizations contains various parameters for modifying the default behavior of certain profiles
 type ProfileCustomizations struct {
+
+	// EnablePodLifetime when set to false will disable the PodLifetime strategy
+	EnablePodLifetime *bool `json:"enablePodLifetime,omitempty"`
+
 	// PodLifetime is the length of time after which pods should be evicted
 	// This field should be used with profiles that enable the PodLifetime strategy, such as LifecycleAndUtilization
 	// +kubebuilder:validation:Format=duration

--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -503,6 +503,15 @@ func (c *TargetConfigReconciler) manageConfigMap(descheduler *deschedulerv1.Kube
 			}
 		}
 
+		if descheduler.Spec.ProfileCustomizations.EnablePodLifetime != nil {
+			if !*descheduler.Spec.ProfileCustomizations.EnablePodLifetime {
+				if strategy, ok := policy.Strategies["PodLifeTime"]; ok {
+					strategy.Enabled = false
+					policy.Strategies["PodLifeTime"] = strategy
+				}
+			}
+		}
+
 		// set priority class threshold if customized
 		if descheduler.Spec.ProfileCustomizations.ThresholdPriority != nil && descheduler.Spec.ProfileCustomizations.ThresholdPriorityClassName != "" {
 			return nil, false, fmt.Errorf("It is invalid to set both .spec.profileCustomizations.thresholdPriority and .spec.profileCustomizations.ThresholdPriorityClassName fields")


### PR DESCRIPTION
Hi,
I'm trying to add a flag to be able to disable podLifetime, I've written the code for it but haven't updated the CRD, I haven't found any `make manifests` or similar to regenerate it so I'm guessing you have some CI for that, is that right?

Do you need me to add something else to the PR?