### PR TITLE
fix: descheduler deployment wrong name

### DIFF
--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -127,10 +127,10 @@ func (c TargetConfigReconciler) sync() error {
 			klog.ErrorS(err, "Error managing targetConfig")
 			_, err = c.kubeClient.AppsV1().Deployments(operatorclient.OperatorNamespace).UpdateScale(
 				c.ctx,
-				descheduler.Name,
+				operatorclient.OperandName,
 				&autoscalingv1.Scale{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      descheduler.Name,
+						Name:      operatorclient.OperandName,
 						Namespace: operatorclient.OperatorNamespace,
 					},
 					Spec: autoscalingv1.ScaleSpec{


### PR DESCRIPTION
While we met error from the configmap and force a deployment scale to 0, the name of descheduler deployment is wrong.

error log by `target_config_reconciler.go` is
```
key failed with : deployments.apps "cluster" not found
```