### PR TITLE
NO-JIRA: Operator deployment: set an emptyDir /tmp

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/openshift/cluster-kube-descheduler-operator
 COPY . .
 RUN make build --warn-undefined-variables
 
-FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.17
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-descheduler-operator/cluster-kube-descheduler-operator /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-descheduler-operator/manifests /manifests
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-descheduler-operator/metadata /metadata

--- a/deploy/0000_00_kube-descheduler-operator.crd.yaml
+++ b/deploy/0000_00_kube-descheduler-operator.crd.yaml
@@ -1,1 +1,1 @@
-../manifests/4.11/kube-descheduler-operator.crd.yaml
+../manifests/kube-descheduler-operator.crd.yaml

--- a/deploy/05_deployment.yaml
+++ b/deploy/05_deployment.yaml
@@ -38,5 +38,11 @@ spec:
               value: "descheduler-operator"
             - name: IMAGE
               value: quay.io/openshift/origin-descheduler:4.9
+          volumeMounts:
+          - name: tmp
+            mountPath: "/tmp"
       serviceAccountName: openshift-descheduler
       serviceAccount: openshift-descheduler
+      volumes:
+      - name: tmp
+        emptyDir: {}

--- a/manifests/cluster-kube-descheduler-operator.clusterserviceversion.yaml
+++ b/manifests/cluster-kube-descheduler-operator.clusterserviceversion.yaml
@@ -253,5 +253,11 @@ spec:
                       value: registry-proxy.engineering.redhat.com/rh-osbs/descheduler-rhel-9:latest
                     - name: OPERAND_VERSION
                       value: 5.0.1
+                  volumeMounts:
+                  - name: tmp
+                    mountPath: "/tmp"
               serviceAccountName: openshift-descheduler
+              volumes:
+              - name: tmp
+                emptyDir: {}
     strategy: deployment

--- a/test/e2e/bindata/assets/05_deployment.yaml
+++ b/test/e2e/bindata/assets/05_deployment.yaml
@@ -23,6 +23,7 @@ spec:
         - name: descheduler-operator
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
           image: # set in e2e
@@ -47,4 +48,10 @@ spec:
               value: "descheduler-operator"
             - name: RELATED_IMAGE_OPERAND_IMAGE
               value: # set in e2e
+          volumeMounts:
+          - name: tmp
+            mountPath: "/tmp"
       serviceAccountName: openshift-descheduler
+      volumes:
+      - name: tmp
+        emptyDir: {}


### PR DESCRIPTION
readOnlyRootFilesystem SecurityContext is enabled by default in Deployment object definition. As a result, /tmp is read-only and not writable.