### PR TITLE
Operator clusterrole needs rbac operand grants

### DIFF
--- a/manifests/cluster-kube-descheduler-operator.clusterserviceversion.yaml
+++ b/manifests/cluster-kube-descheduler-operator.clusterserviceversion.yaml
@@ -188,10 +188,17 @@ spec:
           resources:
           - namespaces
           - pods
+          - nodes
           verbs:
           - get
           - watch
           - list
+        - apiGroups:
+          - ""
+          resources:
+          - pods/eviction
+          verbs:
+          - create
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:
@@ -208,6 +215,14 @@ spec:
           - patch
           - delete
           - deletecollection
+        - apiGroups:
+          - scheduling.k8s.io
+          resources:
+          - priorityclasses
+          verbs:
+          - get
+          - watch
+          - list
         - apiGroups:
           - apps
           resources:


### PR DESCRIPTION
```
E0904 12:58:23.891848       1 target_config_reconciler.go:1044] key failed with : clusterroles.rbac.authorization.k8s.io "openshift-descheduler-operand" is forbidden: user "system:serviceaccount:openshift-kube-descheduler-operator:openshift-descheduler" (groups=["system:serviceaccounts" "system:serviceaccounts:openshift-kube-descheduler-operator" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:
{APIGroups:[""], Resources:["nodes"], Verbs:["get" "watch" "list"]}
{APIGroups:[""], Resources:["pods/eviction"], Verbs:["create"]}
{APIGroups:["scheduling.k8s.io"], Resources:["priorityclasses"], Verbs:["get" "watch" "list"]}
I0904 12:58:23.891932       1 event.go:377] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-descheduler-operator", Name:"descheduler-operator", UID:"6e77bc1d-68f1-4b8c-a333-c01c391bd85b", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ClusterRoleCreateFailed' Failed to create ClusterRole.rbac.authorization.k8s.io/openshift-descheduler-operand: clusterroles.rbac.authorization.k8s.io "openshift-descheduler-operand" is forbidden: user "system:serviceaccount:openshift-kube-descheduler-operator:openshift-descheduler" (groups=["system:serviceaccounts" "system:serviceaccounts:openshift-kube-descheduler-operator" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:
{APIGroups:[""], Resources:["nodes"], Verbs:["get" "watch" "list"]}
{APIGroups:[""], Resources:["pods/eviction"], Verbs:["create"]}
{APIGroups:["scheduling.k8s.io"], Resources:["priorityclasses"], Verbs:["get" "watch" "list"]}
```