### PR TITLE
no-jira: Manifest2clusterrole

### DIFF
--- a/deploy/02_clusterrole.yaml
+++ b/deploy/02_clusterrole.yaml
@@ -3,145 +3,145 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: descheduler-operator
 rules:
-- apiGroups:
-  - operator.openshift.io
-  resources:
-  - "*"
-  verbs:
-  - get
-  - watch
-  - list
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - schedulers
-  verbs:
-  - get
-  - watch
-  - list
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - get
-  - watch
-  - list
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - kubedeschedulers.operator.openshift.io
-  resources:
-  - "*"
-  verbs:
-  - get
-  - watch
-  - list
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - services
-  - serviceaccounts
-  - pods
-  - configmaps
-  - secrets
-  - namespaces
-  - nodes
-  - pods/eviction
-  - events
-  verbs:
-  - get
-  - watch
-  - list
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - clusterroles
-  - clusterrolebindings
-  - roles
-  - rolebindings
-  verbs:
-  - get
-  - watch
-  - list
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - scheduling.k8s.io
-  resources:
-  - priorityclasses
-  verbs:
-  - get
-  - watch
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - deployments/scale
-  - replicasets
-  verbs:
-  - get
-  - watch
-  - list
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - watch
-  - list
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - infrastructures
-  - apiservers
-  verbs:
-  - get
-  - watch
-  - list
-- apiGroups:
-  - events.k8s.io
-  resources:
-  - events
-  verbs:
-  - get
-  - watch
-  - list
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - endpoints
-  verbs:
-  - get
-  - watch
-  - list
+  - apiGroups:
+      - operator.openshift.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - watch
+      - list
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - schedulers
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+      - watch
+      - list
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - kubedeschedulers.operator.openshift.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - watch
+      - list
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - serviceaccounts
+      - pods
+      - configmaps
+      - secrets
+      - namespaces
+      - nodes
+      - pods/eviction
+      - events
+    verbs:
+      - get
+      - watch
+      - list
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+      - clusterrolebindings
+      - roles
+      - rolebindings
+    verbs:
+      - get
+      - watch
+      - list
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - scheduling.k8s.io
+    resources:
+      - priorityclasses
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - deployments/scale
+      - replicasets
+    verbs:
+      - get
+      - watch
+      - list
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - watch
+      - list
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - infrastructures
+      - apiservers
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - get
+      - watch
+      - list
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - get
+      - watch
+      - list

--- a/deploy/02_clusterrole.yaml
+++ b/deploy/02_clusterrole.yaml
@@ -4,18 +4,6 @@ metadata:
   name: descheduler-operator
 rules:
   - apiGroups:
-      - operator.openshift.io
-    resources:
-      - '*'
-    verbs:
-      - get
-      - watch
-      - list
-      - create
-      - update
-      - patch
-      - delete
-  - apiGroups:
       - config.openshift.io
     resources:
       - schedulers
@@ -35,10 +23,12 @@ rules:
       - update
       - patch
       - delete
+      - deletecollection
   - apiGroups:
-      - kubedeschedulers.operator.openshift.io
+      - operator.openshift.io
     resources:
-      - '*'
+      - kubedeschedulers
+      - kubedeschedulers/status
     verbs:
       - get
       - watch
@@ -47,18 +37,15 @@ rules:
       - update
       - patch
       - delete
+      - deletecollection
   - apiGroups:
       - ""
     resources:
       - services
-      - serviceaccounts
-      - pods
       - configmaps
       - secrets
-      - namespaces
-      - nodes
-      - pods/eviction
       - events
+      - serviceaccounts
     verbs:
       - get
       - watch
@@ -67,6 +54,23 @@ rules:
       - update
       - patch
       - delete
+      - deletecollection
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - pods
+      - nodes
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - pods/eviction
+    verbs:
+      - create
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
@@ -82,6 +86,7 @@ rules:
       - update
       - patch
       - delete
+      - deletecollection
   - apiGroups:
       - scheduling.k8s.io
     resources:
@@ -93,9 +98,29 @@ rules:
   - apiGroups:
       - apps
     resources:
+      - replicasets
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - apps
+    resources:
       - deployments
       - deployments/scale
-      - replicasets
+    verbs:
+      - get
+      - watch
+      - list
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
     verbs:
       - get
       - watch
@@ -105,9 +130,9 @@ rules:
       - patch
       - delete
   - apiGroups:
-      - coordination.k8s.io
+      - events.k8s.io
     resources:
-      - leases
+      - events
     verbs:
       - get
       - watch
@@ -125,18 +150,6 @@ rules:
       - get
       - watch
       - list
-  - apiGroups:
-      - events.k8s.io
-    resources:
-      - events
-    verbs:
-      - get
-      - watch
-      - list
-      - create
-      - update
-      - patch
-      - delete
   - apiGroups:
       - ""
     resources:

--- a/hack/manifest2clusterrole.sh
+++ b/hack/manifest2clusterrole.sh
@@ -31,3 +31,4 @@ EOF
 cat ${CURRENT_DIR}/../manifests/cluster-kube-descheduler-operator.clusterserviceversion.yaml | yq -M '.spec.install.spec.clusterPermissions[0].rules' >> deploy/02_clusterrole.yaml
 
 yq -i -P deploy/02_clusterrole.yaml
+cp deploy/02_clusterrole.yaml test/e2e/bindata/assets/03_clusterrole.yaml

--- a/hack/manifest2clusterrole.sh
+++ b/hack/manifest2clusterrole.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+CURRENT_DIR=$(dirname "${BASH_SOURCE}")
+
+cat << EOF > deploy/02_clusterrole.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: descheduler-operator
+rules:
+EOF
+
+cat ${CURRENT_DIR}/../manifests/cluster-kube-descheduler-operator.clusterserviceversion.yaml | yq -M '.spec.install.spec.clusterPermissions[0].rules' >> deploy/02_clusterrole.yaml
+
+yq -i -P deploy/02_clusterrole.yaml

--- a/test/e2e/bindata/assets/03_clusterrole.yaml
+++ b/test/e2e/bindata/assets/03_clusterrole.yaml
@@ -1,153 +1,160 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: openshift-descheduler-operator
+  name: descheduler-operator
 rules:
-- apiGroups:
-  - operator.openshift.io
-  resources:
-  - "*"
-  verbs:
-  - get
-  - watch
-  - list
-  - create
-  - update
-  - patch
-  - delete
-  - deletecollection
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - schedulers
-  verbs:
-  - get
-  - watch
-  - list
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - get
-  - watch
-  - list
-  - create
-  - update
-  - patch
-  - deletecollection
-  - delete
-- apiGroups:
-  - kubedeschedulers.operator.openshift.io
-  resources:
-  - "*"
-  verbs:
-  - get
-  - watch
-  - list
-  - create
-  - update
-  - patch
-  - delete
-  - deletecollection
-- apiGroups:
-  - ""
-  resources:
-  - services
-  - serviceaccounts
-  - pods
-  - configmaps
-  - secrets
-  - namespaces
-  - nodes
-  - pods/eviction
-  - events
-  verbs:
-  - get
-  - watch
-  - list
-  - create
-  - update
-  - patch
-  - deletecollection
-  - delete
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - clusterroles
-  - clusterrolebindings
-  - roles
-  - rolebindings
-  verbs:
-  - get
-  - watch
-  - list
-  - create
-  - update
-  - patch
-  - delete
-  - deletecollection
-- apiGroups:
-  - scheduling.k8s.io
-  resources:
-  - priorityclasses
-  verbs:
-  - get
-  - watch
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - deployments/scale
-  - replicasets
-  verbs:
-  - get
-  - watch
-  - list
-  - create
-  - update
-  - patch
-  - delete
-  - deletecollection
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - watch
-  - list
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - infrastructures
-  - apiservers
-  verbs:
-  - get
-  - watch
-  - list
-- apiGroups:
-  - events.k8s.io
-  resources:
-  - events
-  verbs:
-  - get
-  - watch
-  - list
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - endpoints
-  verbs:
-  - get
-  - watch
-  - list
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - schedulers
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+      - watch
+      - list
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection
+  - apiGroups:
+      - operator.openshift.io
+    resources:
+      - kubedeschedulers
+      - kubedeschedulers/status
+    verbs:
+      - get
+      - watch
+      - list
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - configmaps
+      - secrets
+      - events
+      - serviceaccounts
+    verbs:
+      - get
+      - watch
+      - list
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - pods
+      - nodes
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - pods/eviction
+    verbs:
+      - create
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+      - clusterrolebindings
+      - roles
+      - rolebindings
+    verbs:
+      - get
+      - watch
+      - list
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection
+  - apiGroups:
+      - scheduling.k8s.io
+    resources:
+      - priorityclasses
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - deployments/scale
+    verbs:
+      - get
+      - watch
+      - list
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - watch
+      - list
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - get
+      - watch
+      - list
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - infrastructures
+      - apiservers
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - get
+      - watch
+      - list

--- a/test/e2e/bindata/assets/04_clusterrolebinding.yaml
+++ b/test/e2e/bindata/assets/04_clusterrolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: openshift-descheduler-operator
+  name: descheduler-operator
 subjects:
   - kind: ServiceAccount
     name: openshift-descheduler


### PR DESCRIPTION
To keep the manifest based clusterrole in sync with deploy used for quick development testing.