### PR TITLE
OCPBUGS-41994: Operator clusterrole needs rbac operand grants

### DIFF
--- a/manifests/cluster-kube-descheduler-operator.clusterserviceversion.yaml
+++ b/manifests/cluster-kube-descheduler-operator.clusterserviceversion.yaml
@@ -157,10 +157,17 @@ spec:
           resources:
           - namespaces
           - pods
+          - nodes
           verbs:
           - get
           - watch
           - list
+        - apiGroups:
+          - ""
+          resources:
+          - pods/eviction
+          verbs:
+          - create
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:
@@ -170,6 +177,14 @@ spec:
           - rolebindings
           verbs:
           - '*'
+        - apiGroups:
+          - scheduling.k8s.io
+          resources:
+          - priorityclasses
+          verbs:
+          - get
+          - watch
+          - list
         - apiGroups:
           - apps
           resources:


### PR DESCRIPTION
Backporting https://github.com/openshift/cluster-kube-descheduler-operator/pull/376 to 5.0.z