### PR TITLE
no-jira: Set suggested-namespace and related annotations

### DIFF
--- a/manifests/cluster-kube-descheduler-operator.clusterserviceversion.yaml
+++ b/manifests/cluster-kube-descheduler-operator.clusterserviceversion.yaml
@@ -47,6 +47,9 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional
     operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
+    operatorframework.io/cluster-monitoring: "true"
+    operatorframework.io/suggested-namespace: "openshift-kube-descheduler-operator"
+    console.openshift.io/operator-monitoring-default: "true"
 spec:
   replaces: clusterkubedescheduleroperator.v5.0.1
   # buffering up to 6 5.0.z releases to allow to include these in all supported bundle index images


### PR DESCRIPTION
Add a few annotations:
- operatorframework.io/cluster-monitoring: "true"
- operatorframework.io/suggested-namespace: "openshift-kube-descheduler-operator"
- console.openshift.io/operator-monitoring-default: "true" to simplify the deployment via OCP console.