### PR TITLE
WIP: RelieveAndMigrate: new operator profile for PSI pressure based load-aware descheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ The following profiles are currently provided:
 * [`LifecycleAndUtilization`](#LifecycleAndUtilization)
 * [`LongLifecycle`](#LongLifecycle)
 * [`CompactAndScale`](#compactandscale-techpreview)
+* [`RelieveAndMigrate`](#relieveandmigrate-techpreview)
 * [`EvictPodsWithPVC`](#EvictPodsWithPVC)
 * [`EvictPodsWithLocalStorage`](#EvictPodsWithLocalStorage)
 
@@ -151,6 +152,25 @@ An under utilized node is any node consuming less than 20% of its available cpu,
 This profile enables the [`HighNodeUtilization`](https://github.com/kubernetes-sigs/descheduler/#highnodeutilization) strategy.
 In the future, more configuration may be made available through the operator based on user feedback.
 
+### RelieveAndMigrate
+
+This profiles seeks to evict pods from high-cost nodes to relieve overall expenses while considering workload migration.
+Node cost can include:
+- Actual resource utilization: Increased resource pressure leads to higher overhead for running applications.
+- Node maintenance costs: A higher number of containers on a node results in greater resource counting.
+Migration strategies may involve VM live migration, state transitions between stateful set pods, and other methods.
+
+This profile enables the [`LowNodeUtilization`](https://github.com/kubernetes-sigs/descheduler/#lownodeutilization) strategy
+with `EvictionsInBackground` alpha feature enabled.
+In the future, more configuration may be made available through the operator based on user feedback.
+
+The profile exposes the following customization:
+- `devLowNodeUtilizationThresholds`: Sets experimental thresholds for the LowNodeUtilization strategy.
+- `devActualUtilizationProfile`: Enable load-aware descheduling.
+- `devDeviationThresholds`: Have the thresholds be based on the average utilization.
+- `devMultiSoftTainting`: For applying multiple soft-taints instead of a single one.
+- `devMultiEvictions`: Evict multiple pods per node during a descheduling cycle.
+
 ### EvictPodsWithPVC
 By default, the operator prevents pods with PVCs from being evicted. Enabling this
 profile in combination with any of the above profiles allows pods with PVCs to be
@@ -177,6 +197,9 @@ the `profileCustomizations` field:
 |`devEnableEvictionsInBackground`|`bool`| Enables descheduler's EvictionsInBackground alpha feature. The EvictionsInBackground alpha feature is a subject to change. Currently provided as an experimental feature.|
 | `devHighNodeUtilizationThresholds` | `string` | Sets thresholds for the [HighNodeUtilization](https://github.com/kubernetes-sigs/descheduler#highnodeutilization) strategy of the `CompactAndScale` profile in the following ratios: `Minimal` for 10%, `Modest` for 20%, `Moderate` for 30%. Currently provided as an experimental feature.|
 |`devActualUtilizationProfile`|`string`| Sets a profile that gets translated into a predefined prometheus query |
+| `devDeviationThresholds` | `string` | Have the thresholds be based on the average utilization. Thresholds signify the distance from the average node utilization in the following setting: `Low`: 10%:10%, `Medium`: 20%:20%, `High`: 30%:30% |
+| `devMultiSoftTainting` | `string` | To apply multiple soft-taints instead of just one: `Static` for a single taint, `Dynamic` for one or more, depending on the remaining utilization. |
+| `devMultiEvictions` | `string` |  Evict multiple pods per node during a descheduling cycle: `Simple` for 1 (default), `Modest` for 2, `Rapid` for `5`. |
 
 ## Prometheus query profiles
 The operator provides the following profiles:

--- a/pkg/apis/descheduler/v1/types_descheduler.go
+++ b/pkg/apis/descheduler/v1/types_descheduler.go
@@ -90,6 +90,18 @@ type ProfileCustomizations struct {
 	// LowNodeUtilization plugin can consume the metrics for now.
 	// Currently provided as an experimental feature.
 	DevActualUtilizationProfile ActualUtilizationProfile `json:"devActualUtilizationProfile,omitempty"`
+
+	// devDeviationThresholds enables dynamic thresholds based on average resource utilization
+	// +kubebuilder:validation:Enum=Low;Medium;High;""
+	DevDeviationThresholds *DeviationThresholdsType `json:"devDeviationThresholds,omitempty"`
+
+	// To apply multiple soft-taints instead of just one
+	// +kubebuilder:validation:Enum=Static;Dynamic;""
+	DevMultiSoftTainting *MultiSoftTaintingType `json:"devMultiSoftTainting,omitempty"`
+
+	// Evict multiple pods per node during a descheduling cycle
+	// +kubebuilder:validation:Enum=Simple;Modest;Rapid;""
+	DevMultiEvictions *MultiEvictionsType `json:"devMultiEvictions,omitempty"`
 }
 
 type LowNodeUtilizationThresholdsType string
@@ -119,6 +131,48 @@ var (
 	// CompactHighThreshold sets thresholds to 30% ratio.
 	// The threshold value is subject to change.
 	CompactModerateThreshold HighNodeUtilizationThresholdsType = "Moderate"
+)
+
+type DeviationThresholdsType string
+
+var (
+	// DeviationThresholdLow sets thresholds to 10%:10% ratio.
+	// The threshold value is subject to change.
+	DeviationThresholdLow DeviationThresholdsType = "Low"
+
+	// DeviationThresholdMedium sets thresholds to 20%:20% ratio.
+	// The threshold value is subject to change.
+	DeviationThresholdMedium DeviationThresholdsType = "Medium"
+
+	// DeviationThresholdHigh sets thresholds to 30%:30% ratio.
+	// The threshold value is subject to change.
+	DeviationThresholdHigh DeviationThresholdsType = "High"
+)
+
+type MultiSoftTaintingType string
+
+var (
+	// MultiSoftTaintingStatic taints a node with a single soft taint
+	MultiSoftTaintingStatic MultiSoftTaintingType = "Static"
+
+	// MultiSoftTaintingDynamic taints a node with one or more soft taints, depending on the remaining utilization.
+	MultiSoftTaintingDynamic MultiSoftTaintingType = "Dynamic"
+)
+
+type MultiEvictionsType string
+
+var (
+	// MultiEvictionsSimple evicts a single pod during a descheduling cycle
+	// The value is subject to change.
+	MultiEvictionsSimple MultiEvictionsType = "Simple"
+
+	// MultiEvictionsSimple evicts two pods during a descheduling cycle
+	// The value is subject to change.
+	MultiEvictionsModest MultiEvictionsType = "Modest"
+
+	// MultiEvictionsSimple evicts five pods during a descheduling cycle
+	// The value is subject to change.
+	MultiEvictionsRapid MultiEvictionsType = "Rapid"
 )
 
 // ActualUtilizationProfile sets predefined Prometheus PromQL query
@@ -178,6 +232,9 @@ var (
 
 	// CompactAndScale seeks to evict pods to enable the same workload to run on a smaller set of nodes.
 	CompactAndScale DeschedulerProfile = "CompactAndScale"
+
+	// RelieveAndMigrate seeks to evict pods from high-cost nodes to relieve overall expenses while considering workload migration.
+	RelieveAndMigrate DeschedulerProfile = "RelieveAndMigrate"
 )
 
 // DeschedulerProfile allows configuring the enabled strategy profiles for the descheduler

--- a/pkg/apis/descheduler/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/descheduler/v1/zz_generated.deepcopy.go
@@ -196,6 +196,21 @@ func (in *ProfileCustomizations) DeepCopyInto(out *ProfileCustomizations) {
 		*out = new(HighNodeUtilizationThresholdsType)
 		**out = **in
 	}
+	if in.DevDeviationThresholds != nil {
+		in, out := &in.DevDeviationThresholds, &out.DevDeviationThresholds
+		*out = new(DeviationThresholdsType)
+		**out = **in
+	}
+	if in.DevMultiSoftTainting != nil {
+		in, out := &in.DevMultiSoftTainting, &out.DevMultiSoftTainting
+		*out = new(MultiSoftTaintingType)
+		**out = **in
+	}
+	if in.DevMultiEvictions != nil {
+		in, out := &in.DevMultiEvictions, &out.DevMultiEvictions
+		*out = new(MultiEvictionsType)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/generated/applyconfiguration/descheduler/v1/kubedescheduler.go
+++ b/pkg/generated/applyconfiguration/descheduler/v1/kubedescheduler.go
@@ -3,21 +3,21 @@
 package v1
 
 import (
-	apisdeschedulerv1 "github.com/openshift/cluster-kube-descheduler-operator/pkg/apis/descheduler/v1"
+	deschedulerv1 "github.com/openshift/cluster-kube-descheduler-operator/pkg/apis/descheduler/v1"
 	internal "github.com/openshift/cluster-kube-descheduler-operator/pkg/generated/applyconfiguration/internal"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
-	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
+	metav1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
 // KubeDeschedulerApplyConfiguration represents a declarative configuration of the KubeDescheduler type for use
 // with apply.
 type KubeDeschedulerApplyConfiguration struct {
-	v1.TypeMetaApplyConfiguration    `json:",inline"`
-	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	Spec                             *KubeDeschedulerSpecApplyConfiguration   `json:"spec,omitempty"`
-	Status                           *KubeDeschedulerStatusApplyConfiguration `json:"status,omitempty"`
+	metav1.TypeMetaApplyConfiguration    `json:",inline"`
+	*metav1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
+	Spec                                 *KubeDeschedulerSpecApplyConfiguration   `json:"spec,omitempty"`
+	Status                               *KubeDeschedulerStatusApplyConfiguration `json:"status,omitempty"`
 }
 
 // KubeDescheduler constructs a declarative configuration of the KubeDescheduler type for use with
@@ -42,18 +42,18 @@ func KubeDescheduler(name, namespace string) *KubeDeschedulerApplyConfiguration 
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractKubeDescheduler(kubeDescheduler *apisdeschedulerv1.KubeDescheduler, fieldManager string) (*KubeDeschedulerApplyConfiguration, error) {
+func ExtractKubeDescheduler(kubeDescheduler *deschedulerv1.KubeDescheduler, fieldManager string) (*KubeDeschedulerApplyConfiguration, error) {
 	return extractKubeDescheduler(kubeDescheduler, fieldManager, "")
 }
 
 // ExtractKubeDeschedulerStatus is the same as ExtractKubeDescheduler except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractKubeDeschedulerStatus(kubeDescheduler *apisdeschedulerv1.KubeDescheduler, fieldManager string) (*KubeDeschedulerApplyConfiguration, error) {
+func ExtractKubeDeschedulerStatus(kubeDescheduler *deschedulerv1.KubeDescheduler, fieldManager string) (*KubeDeschedulerApplyConfiguration, error) {
 	return extractKubeDescheduler(kubeDescheduler, fieldManager, "status")
 }
 
-func extractKubeDescheduler(kubeDescheduler *apisdeschedulerv1.KubeDescheduler, fieldManager string, subresource string) (*KubeDeschedulerApplyConfiguration, error) {
+func extractKubeDescheduler(kubeDescheduler *deschedulerv1.KubeDescheduler, fieldManager string, subresource string) (*KubeDeschedulerApplyConfiguration, error) {
 	b := &KubeDeschedulerApplyConfiguration{}
 	err := managedfields.ExtractInto(kubeDescheduler, internal.Parser().Type("com.github.openshift.cluster-kube-descheduler-operator.pkg.apis.descheduler.v1.KubeDescheduler"), fieldManager, b, subresource)
 	if err != nil {
@@ -71,7 +71,7 @@ func extractKubeDescheduler(kubeDescheduler *apisdeschedulerv1.KubeDescheduler, 
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Kind field is set to the value of the last call.
 func (b *KubeDeschedulerApplyConfiguration) WithKind(value string) *KubeDeschedulerApplyConfiguration {
-	b.Kind = &value
+	b.TypeMetaApplyConfiguration.Kind = &value
 	return b
 }
 
@@ -79,7 +79,7 @@ func (b *KubeDeschedulerApplyConfiguration) WithKind(value string) *KubeDeschedu
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the APIVersion field is set to the value of the last call.
 func (b *KubeDeschedulerApplyConfiguration) WithAPIVersion(value string) *KubeDeschedulerApplyConfiguration {
-	b.APIVersion = &value
+	b.TypeMetaApplyConfiguration.APIVersion = &value
 	return b
 }
 
@@ -88,7 +88,7 @@ func (b *KubeDeschedulerApplyConfiguration) WithAPIVersion(value string) *KubeDe
 // If called multiple times, the Name field is set to the value of the last call.
 func (b *KubeDeschedulerApplyConfiguration) WithName(value string) *KubeDeschedulerApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
-	b.Name = &value
+	b.ObjectMetaApplyConfiguration.Name = &value
 	return b
 }
 
@@ -97,7 +97,7 @@ func (b *KubeDeschedulerApplyConfiguration) WithName(value string) *KubeDeschedu
 // If called multiple times, the GenerateName field is set to the value of the last call.
 func (b *KubeDeschedulerApplyConfiguration) WithGenerateName(value string) *KubeDeschedulerApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
-	b.GenerateName = &value
+	b.ObjectMetaApplyConfiguration.GenerateName = &value
 	return b
 }
 
@@ -106,7 +106,7 @@ func (b *KubeDeschedulerApplyConfiguration) WithGenerateName(value string) *Kube
 // If called multiple times, the Namespace field is set to the value of the last call.
 func (b *KubeDeschedulerApplyConfiguration) WithNamespace(value string) *KubeDeschedulerApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
-	b.Namespace = &value
+	b.ObjectMetaApplyConfiguration.Namespace = &value
 	return b
 }
 
@@ -115,7 +115,7 @@ func (b *KubeDeschedulerApplyConfiguration) WithNamespace(value string) *KubeDes
 // If called multiple times, the UID field is set to the value of the last call.
 func (b *KubeDeschedulerApplyConfiguration) WithUID(value types.UID) *KubeDeschedulerApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
-	b.UID = &value
+	b.ObjectMetaApplyConfiguration.UID = &value
 	return b
 }
 
@@ -124,7 +124,7 @@ func (b *KubeDeschedulerApplyConfiguration) WithUID(value types.UID) *KubeDesche
 // If called multiple times, the ResourceVersion field is set to the value of the last call.
 func (b *KubeDeschedulerApplyConfiguration) WithResourceVersion(value string) *KubeDeschedulerApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
-	b.ResourceVersion = &value
+	b.ObjectMetaApplyConfiguration.ResourceVersion = &value
 	return b
 }
 
@@ -133,25 +133,25 @@ func (b *KubeDeschedulerApplyConfiguration) WithResourceVersion(value string) *K
 // If called multiple times, the Generation field is set to the value of the last call.
 func (b *KubeDeschedulerApplyConfiguration) WithGeneration(value int64) *KubeDeschedulerApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
-	b.Generation = &value
+	b.ObjectMetaApplyConfiguration.Generation = &value
 	return b
 }
 
 // WithCreationTimestamp sets the CreationTimestamp field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the CreationTimestamp field is set to the value of the last call.
-func (b *KubeDeschedulerApplyConfiguration) WithCreationTimestamp(value metav1.Time) *KubeDeschedulerApplyConfiguration {
+func (b *KubeDeschedulerApplyConfiguration) WithCreationTimestamp(value apismetav1.Time) *KubeDeschedulerApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
-	b.CreationTimestamp = &value
+	b.ObjectMetaApplyConfiguration.CreationTimestamp = &value
 	return b
 }
 
 // WithDeletionTimestamp sets the DeletionTimestamp field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the DeletionTimestamp field is set to the value of the last call.
-func (b *KubeDeschedulerApplyConfiguration) WithDeletionTimestamp(value metav1.Time) *KubeDeschedulerApplyConfiguration {
+func (b *KubeDeschedulerApplyConfiguration) WithDeletionTimestamp(value apismetav1.Time) *KubeDeschedulerApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
-	b.DeletionTimestamp = &value
+	b.ObjectMetaApplyConfiguration.DeletionTimestamp = &value
 	return b
 }
 
@@ -160,7 +160,7 @@ func (b *KubeDeschedulerApplyConfiguration) WithDeletionTimestamp(value metav1.T
 // If called multiple times, the DeletionGracePeriodSeconds field is set to the value of the last call.
 func (b *KubeDeschedulerApplyConfiguration) WithDeletionGracePeriodSeconds(value int64) *KubeDeschedulerApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
-	b.DeletionGracePeriodSeconds = &value
+	b.ObjectMetaApplyConfiguration.DeletionGracePeriodSeconds = &value
 	return b
 }
 
@@ -170,11 +170,11 @@ func (b *KubeDeschedulerApplyConfiguration) WithDeletionGracePeriodSeconds(value
 // overwriting an existing map entries in Labels field with the same key.
 func (b *KubeDeschedulerApplyConfiguration) WithLabels(entries map[string]string) *KubeDeschedulerApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
-	if b.Labels == nil && len(entries) > 0 {
-		b.Labels = make(map[string]string, len(entries))
+	if b.ObjectMetaApplyConfiguration.Labels == nil && len(entries) > 0 {
+		b.ObjectMetaApplyConfiguration.Labels = make(map[string]string, len(entries))
 	}
 	for k, v := range entries {
-		b.Labels[k] = v
+		b.ObjectMetaApplyConfiguration.Labels[k] = v
 	}
 	return b
 }
@@ -185,11 +185,11 @@ func (b *KubeDeschedulerApplyConfiguration) WithLabels(entries map[string]string
 // overwriting an existing map entries in Annotations field with the same key.
 func (b *KubeDeschedulerApplyConfiguration) WithAnnotations(entries map[string]string) *KubeDeschedulerApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
-	if b.Annotations == nil && len(entries) > 0 {
-		b.Annotations = make(map[string]string, len(entries))
+	if b.ObjectMetaApplyConfiguration.Annotations == nil && len(entries) > 0 {
+		b.ObjectMetaApplyConfiguration.Annotations = make(map[string]string, len(entries))
 	}
 	for k, v := range entries {
-		b.Annotations[k] = v
+		b.ObjectMetaApplyConfiguration.Annotations[k] = v
 	}
 	return b
 }
@@ -197,13 +197,13 @@ func (b *KubeDeschedulerApplyConfiguration) WithAnnotations(entries map[string]s
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
-func (b *KubeDeschedulerApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *KubeDeschedulerApplyConfiguration {
+func (b *KubeDeschedulerApplyConfiguration) WithOwnerReferences(values ...*metav1.OwnerReferenceApplyConfiguration) *KubeDeschedulerApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithOwnerReferences")
 		}
-		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+		b.ObjectMetaApplyConfiguration.OwnerReferences = append(b.ObjectMetaApplyConfiguration.OwnerReferences, *values[i])
 	}
 	return b
 }
@@ -214,14 +214,14 @@ func (b *KubeDeschedulerApplyConfiguration) WithOwnerReferences(values ...*v1.Ow
 func (b *KubeDeschedulerApplyConfiguration) WithFinalizers(values ...string) *KubeDeschedulerApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
-		b.Finalizers = append(b.Finalizers, values[i])
+		b.ObjectMetaApplyConfiguration.Finalizers = append(b.ObjectMetaApplyConfiguration.Finalizers, values[i])
 	}
 	return b
 }
 
 func (b *KubeDeschedulerApplyConfiguration) ensureObjectMetaApplyConfigurationExists() {
 	if b.ObjectMetaApplyConfiguration == nil {
-		b.ObjectMetaApplyConfiguration = &v1.ObjectMetaApplyConfiguration{}
+		b.ObjectMetaApplyConfiguration = &metav1.ObjectMetaApplyConfiguration{}
 	}
 }
 
@@ -244,5 +244,5 @@ func (b *KubeDeschedulerApplyConfiguration) WithStatus(value *KubeDeschedulerSta
 // GetName retrieves the value of the Name field in the declarative configuration.
 func (b *KubeDeschedulerApplyConfiguration) GetName() *string {
 	b.ensureObjectMetaApplyConfigurationExists()
-	return b.Name
+	return b.ObjectMetaApplyConfiguration.Name
 }

--- a/pkg/generated/applyconfiguration/descheduler/v1/kubedeschedulerspec.go
+++ b/pkg/generated/applyconfiguration/descheduler/v1/kubedeschedulerspec.go
@@ -3,8 +3,8 @@
 package v1
 
 import (
-	operatorv1 "github.com/openshift/api/operator/v1"
-	v1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
+	apioperatorv1 "github.com/openshift/api/operator/v1"
+	operatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
 	deschedulerv1 "github.com/openshift/cluster-kube-descheduler-operator/pkg/apis/descheduler/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -12,12 +12,12 @@ import (
 // KubeDeschedulerSpecApplyConfiguration represents a declarative configuration of the KubeDeschedulerSpec type for use
 // with apply.
 type KubeDeschedulerSpecApplyConfiguration struct {
-	v1.OperatorSpecApplyConfiguration `json:",inline"`
-	Profiles                          []deschedulerv1.DeschedulerProfile       `json:"profiles,omitempty"`
-	DeschedulingIntervalSeconds       *int32                                   `json:"deschedulingIntervalSeconds,omitempty"`
-	EvictionLimits                    *EvictionLimitsApplyConfiguration        `json:"evictionLimits,omitempty"`
-	ProfileCustomizations             *ProfileCustomizationsApplyConfiguration `json:"profileCustomizations,omitempty"`
-	Mode                              *deschedulerv1.Mode                      `json:"mode,omitempty"`
+	operatorv1.OperatorSpecApplyConfiguration `json:",inline"`
+	Profiles                                  []deschedulerv1.DeschedulerProfile       `json:"profiles,omitempty"`
+	DeschedulingIntervalSeconds               *int32                                   `json:"deschedulingIntervalSeconds,omitempty"`
+	EvictionLimits                            *EvictionLimitsApplyConfiguration        `json:"evictionLimits,omitempty"`
+	ProfileCustomizations                     *ProfileCustomizationsApplyConfiguration `json:"profileCustomizations,omitempty"`
+	Mode                                      *deschedulerv1.Mode                      `json:"mode,omitempty"`
 }
 
 // KubeDeschedulerSpecApplyConfiguration constructs a declarative configuration of the KubeDeschedulerSpec type for use with
@@ -29,24 +29,24 @@ func KubeDeschedulerSpec() *KubeDeschedulerSpecApplyConfiguration {
 // WithManagementState sets the ManagementState field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the ManagementState field is set to the value of the last call.
-func (b *KubeDeschedulerSpecApplyConfiguration) WithManagementState(value operatorv1.ManagementState) *KubeDeschedulerSpecApplyConfiguration {
-	b.ManagementState = &value
+func (b *KubeDeschedulerSpecApplyConfiguration) WithManagementState(value apioperatorv1.ManagementState) *KubeDeschedulerSpecApplyConfiguration {
+	b.OperatorSpecApplyConfiguration.ManagementState = &value
 	return b
 }
 
 // WithLogLevel sets the LogLevel field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the LogLevel field is set to the value of the last call.
-func (b *KubeDeschedulerSpecApplyConfiguration) WithLogLevel(value operatorv1.LogLevel) *KubeDeschedulerSpecApplyConfiguration {
-	b.LogLevel = &value
+func (b *KubeDeschedulerSpecApplyConfiguration) WithLogLevel(value apioperatorv1.LogLevel) *KubeDeschedulerSpecApplyConfiguration {
+	b.OperatorSpecApplyConfiguration.LogLevel = &value
 	return b
 }
 
 // WithOperatorLogLevel sets the OperatorLogLevel field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the OperatorLogLevel field is set to the value of the last call.
-func (b *KubeDeschedulerSpecApplyConfiguration) WithOperatorLogLevel(value operatorv1.LogLevel) *KubeDeschedulerSpecApplyConfiguration {
-	b.OperatorLogLevel = &value
+func (b *KubeDeschedulerSpecApplyConfiguration) WithOperatorLogLevel(value apioperatorv1.LogLevel) *KubeDeschedulerSpecApplyConfiguration {
+	b.OperatorSpecApplyConfiguration.OperatorLogLevel = &value
 	return b
 }
 
@@ -54,7 +54,7 @@ func (b *KubeDeschedulerSpecApplyConfiguration) WithOperatorLogLevel(value opera
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the UnsupportedConfigOverrides field is set to the value of the last call.
 func (b *KubeDeschedulerSpecApplyConfiguration) WithUnsupportedConfigOverrides(value runtime.RawExtension) *KubeDeschedulerSpecApplyConfiguration {
-	b.UnsupportedConfigOverrides = &value
+	b.OperatorSpecApplyConfiguration.UnsupportedConfigOverrides = &value
 	return b
 }
 
@@ -62,7 +62,7 @@ func (b *KubeDeschedulerSpecApplyConfiguration) WithUnsupportedConfigOverrides(v
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the ObservedConfig field is set to the value of the last call.
 func (b *KubeDeschedulerSpecApplyConfiguration) WithObservedConfig(value runtime.RawExtension) *KubeDeschedulerSpecApplyConfiguration {
-	b.ObservedConfig = &value
+	b.OperatorSpecApplyConfiguration.ObservedConfig = &value
 	return b
 }
 

--- a/pkg/generated/applyconfiguration/descheduler/v1/kubedeschedulerstatus.go
+++ b/pkg/generated/applyconfiguration/descheduler/v1/kubedeschedulerstatus.go
@@ -3,13 +3,13 @@
 package v1
 
 import (
-	v1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
+	operatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
 )
 
 // KubeDeschedulerStatusApplyConfiguration represents a declarative configuration of the KubeDeschedulerStatus type for use
 // with apply.
 type KubeDeschedulerStatusApplyConfiguration struct {
-	v1.OperatorStatusApplyConfiguration `json:",inline"`
+	operatorv1.OperatorStatusApplyConfiguration `json:",inline"`
 }
 
 // KubeDeschedulerStatusApplyConfiguration constructs a declarative configuration of the KubeDeschedulerStatus type for use with
@@ -22,19 +22,19 @@ func KubeDeschedulerStatus() *KubeDeschedulerStatusApplyConfiguration {
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the ObservedGeneration field is set to the value of the last call.
 func (b *KubeDeschedulerStatusApplyConfiguration) WithObservedGeneration(value int64) *KubeDeschedulerStatusApplyConfiguration {
-	b.ObservedGeneration = &value
+	b.OperatorStatusApplyConfiguration.ObservedGeneration = &value
 	return b
 }
 
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Conditions field.
-func (b *KubeDeschedulerStatusApplyConfiguration) WithConditions(values ...*v1.OperatorConditionApplyConfiguration) *KubeDeschedulerStatusApplyConfiguration {
+func (b *KubeDeschedulerStatusApplyConfiguration) WithConditions(values ...*operatorv1.OperatorConditionApplyConfiguration) *KubeDeschedulerStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithConditions")
 		}
-		b.Conditions = append(b.Conditions, *values[i])
+		b.OperatorStatusApplyConfiguration.Conditions = append(b.OperatorStatusApplyConfiguration.Conditions, *values[i])
 	}
 	return b
 }
@@ -43,7 +43,7 @@ func (b *KubeDeschedulerStatusApplyConfiguration) WithConditions(values ...*v1.O
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Version field is set to the value of the last call.
 func (b *KubeDeschedulerStatusApplyConfiguration) WithVersion(value string) *KubeDeschedulerStatusApplyConfiguration {
-	b.Version = &value
+	b.OperatorStatusApplyConfiguration.Version = &value
 	return b
 }
 
@@ -51,7 +51,7 @@ func (b *KubeDeschedulerStatusApplyConfiguration) WithVersion(value string) *Kub
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the ReadyReplicas field is set to the value of the last call.
 func (b *KubeDeschedulerStatusApplyConfiguration) WithReadyReplicas(value int32) *KubeDeschedulerStatusApplyConfiguration {
-	b.ReadyReplicas = &value
+	b.OperatorStatusApplyConfiguration.ReadyReplicas = &value
 	return b
 }
 
@@ -59,19 +59,19 @@ func (b *KubeDeschedulerStatusApplyConfiguration) WithReadyReplicas(value int32)
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the LatestAvailableRevision field is set to the value of the last call.
 func (b *KubeDeschedulerStatusApplyConfiguration) WithLatestAvailableRevision(value int32) *KubeDeschedulerStatusApplyConfiguration {
-	b.LatestAvailableRevision = &value
+	b.OperatorStatusApplyConfiguration.LatestAvailableRevision = &value
 	return b
 }
 
 // WithGenerations adds the given value to the Generations field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Generations field.
-func (b *KubeDeschedulerStatusApplyConfiguration) WithGenerations(values ...*v1.GenerationStatusApplyConfiguration) *KubeDeschedulerStatusApplyConfiguration {
+func (b *KubeDeschedulerStatusApplyConfiguration) WithGenerations(values ...*operatorv1.GenerationStatusApplyConfiguration) *KubeDeschedulerStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithGenerations")
 		}
-		b.Generations = append(b.Generations, *values[i])
+		b.OperatorStatusApplyConfiguration.Generations = append(b.OperatorStatusApplyConfiguration.Generations, *values[i])
 	}
 	return b
 }

--- a/pkg/generated/applyconfiguration/descheduler/v1/profilecustomizations.go
+++ b/pkg/generated/applyconfiguration/descheduler/v1/profilecustomizations.go
@@ -3,21 +3,24 @@
 package v1
 
 import (
-	apisdeschedulerv1 "github.com/openshift/cluster-kube-descheduler-operator/pkg/apis/descheduler/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	deschedulerv1 "github.com/openshift/cluster-kube-descheduler-operator/pkg/apis/descheduler/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ProfileCustomizationsApplyConfiguration represents a declarative configuration of the ProfileCustomizations type for use
 // with apply.
 type ProfileCustomizationsApplyConfiguration struct {
-	PodLifetime                      *v1.Duration                                         `json:"podLifetime,omitempty"`
-	ThresholdPriority                *int32                                               `json:"thresholdPriority,omitempty"`
-	ThresholdPriorityClassName       *string                                              `json:"thresholdPriorityClassName,omitempty"`
-	Namespaces                       *NamespacesApplyConfiguration                        `json:"namespaces,omitempty"`
-	DevLowNodeUtilizationThresholds  *apisdeschedulerv1.LowNodeUtilizationThresholdsType  `json:"devLowNodeUtilizationThresholds,omitempty"`
-	DevEnableEvictionsInBackground   *bool                                                `json:"devEnableEvictionsInBackground,omitempty"`
-	DevHighNodeUtilizationThresholds *apisdeschedulerv1.HighNodeUtilizationThresholdsType `json:"devHighNodeUtilizationThresholds,omitempty"`
-	DevActualUtilizationProfile      *apisdeschedulerv1.ActualUtilizationProfile          `json:"devActualUtilizationProfile,omitempty"`
+	PodLifetime                      *metav1.Duration                                 `json:"podLifetime,omitempty"`
+	ThresholdPriority                *int32                                           `json:"thresholdPriority,omitempty"`
+	ThresholdPriorityClassName       *string                                          `json:"thresholdPriorityClassName,omitempty"`
+	Namespaces                       *NamespacesApplyConfiguration                    `json:"namespaces,omitempty"`
+	DevLowNodeUtilizationThresholds  *deschedulerv1.LowNodeUtilizationThresholdsType  `json:"devLowNodeUtilizationThresholds,omitempty"`
+	DevEnableEvictionsInBackground   *bool                                            `json:"devEnableEvictionsInBackground,omitempty"`
+	DevHighNodeUtilizationThresholds *deschedulerv1.HighNodeUtilizationThresholdsType `json:"devHighNodeUtilizationThresholds,omitempty"`
+	DevActualUtilizationProfile      *deschedulerv1.ActualUtilizationProfile          `json:"devActualUtilizationProfile,omitempty"`
+	DevDeviationThresholds           *deschedulerv1.DeviationThresholdsType           `json:"devDeviationThresholds,omitempty"`
+	DevMultiSoftTainting             *deschedulerv1.MultiSoftTaintingType             `json:"devMultiSoftTainting,omitempty"`
+	DevMultiEvictions                *deschedulerv1.MultiEvictionsType                `json:"devMultiEvictions,omitempty"`
 }
 
 // ProfileCustomizationsApplyConfiguration constructs a declarative configuration of the ProfileCustomizations type for use with
@@ -29,7 +32,7 @@ func ProfileCustomizations() *ProfileCustomizationsApplyConfiguration {
 // WithPodLifetime sets the PodLifetime field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the PodLifetime field is set to the value of the last call.
-func (b *ProfileCustomizationsApplyConfiguration) WithPodLifetime(value v1.Duration) *ProfileCustomizationsApplyConfiguration {
+func (b *ProfileCustomizationsApplyConfiguration) WithPodLifetime(value metav1.Duration) *ProfileCustomizationsApplyConfiguration {
 	b.PodLifetime = &value
 	return b
 }
@@ -61,7 +64,7 @@ func (b *ProfileCustomizationsApplyConfiguration) WithNamespaces(value *Namespac
 // WithDevLowNodeUtilizationThresholds sets the DevLowNodeUtilizationThresholds field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the DevLowNodeUtilizationThresholds field is set to the value of the last call.
-func (b *ProfileCustomizationsApplyConfiguration) WithDevLowNodeUtilizationThresholds(value apisdeschedulerv1.LowNodeUtilizationThresholdsType) *ProfileCustomizationsApplyConfiguration {
+func (b *ProfileCustomizationsApplyConfiguration) WithDevLowNodeUtilizationThresholds(value deschedulerv1.LowNodeUtilizationThresholdsType) *ProfileCustomizationsApplyConfiguration {
 	b.DevLowNodeUtilizationThresholds = &value
 	return b
 }
@@ -77,7 +80,7 @@ func (b *ProfileCustomizationsApplyConfiguration) WithDevEnableEvictionsInBackgr
 // WithDevHighNodeUtilizationThresholds sets the DevHighNodeUtilizationThresholds field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the DevHighNodeUtilizationThresholds field is set to the value of the last call.
-func (b *ProfileCustomizationsApplyConfiguration) WithDevHighNodeUtilizationThresholds(value apisdeschedulerv1.HighNodeUtilizationThresholdsType) *ProfileCustomizationsApplyConfiguration {
+func (b *ProfileCustomizationsApplyConfiguration) WithDevHighNodeUtilizationThresholds(value deschedulerv1.HighNodeUtilizationThresholdsType) *ProfileCustomizationsApplyConfiguration {
 	b.DevHighNodeUtilizationThresholds = &value
 	return b
 }
@@ -85,7 +88,31 @@ func (b *ProfileCustomizationsApplyConfiguration) WithDevHighNodeUtilizationThre
 // WithDevActualUtilizationProfile sets the DevActualUtilizationProfile field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the DevActualUtilizationProfile field is set to the value of the last call.
-func (b *ProfileCustomizationsApplyConfiguration) WithDevActualUtilizationProfile(value apisdeschedulerv1.ActualUtilizationProfile) *ProfileCustomizationsApplyConfiguration {
+func (b *ProfileCustomizationsApplyConfiguration) WithDevActualUtilizationProfile(value deschedulerv1.ActualUtilizationProfile) *ProfileCustomizationsApplyConfiguration {
 	b.DevActualUtilizationProfile = &value
+	return b
+}
+
+// WithDevDeviationThresholds sets the DevDeviationThresholds field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the DevDeviationThresholds field is set to the value of the last call.
+func (b *ProfileCustomizationsApplyConfiguration) WithDevDeviationThresholds(value deschedulerv1.DeviationThresholdsType) *ProfileCustomizationsApplyConfiguration {
+	b.DevDeviationThresholds = &value
+	return b
+}
+
+// WithDevMultiSoftTainting sets the DevMultiSoftTainting field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the DevMultiSoftTainting field is set to the value of the last call.
+func (b *ProfileCustomizationsApplyConfiguration) WithDevMultiSoftTainting(value deschedulerv1.MultiSoftTaintingType) *ProfileCustomizationsApplyConfiguration {
+	b.DevMultiSoftTainting = &value
+	return b
+}
+
+// WithDevMultiEvictions sets the DevMultiEvictions field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the DevMultiEvictions field is set to the value of the last call.
+func (b *ProfileCustomizationsApplyConfiguration) WithDevMultiEvictions(value deschedulerv1.MultiEvictionsType) *ProfileCustomizationsApplyConfiguration {
+	b.DevMultiEvictions = &value
 	return b
 }

--- a/pkg/generated/applyconfiguration/internal/internal.go
+++ b/pkg/generated/applyconfiguration/internal/internal.go
@@ -3,8 +3,8 @@
 package internal
 
 import (
-	"fmt"
-	"sync"
+	fmt "fmt"
+	sync "sync"
 
 	typed "sigs.k8s.io/structured-merge-diff/v4/typed"
 )

--- a/pkg/generated/clientset/versioned/clientset.go
+++ b/pkg/generated/clientset/versioned/clientset.go
@@ -3,8 +3,8 @@
 package versioned
 
 import (
-	"fmt"
-	"net/http"
+	fmt "fmt"
+	http "net/http"
 
 	kubedeschedulersv1 "github.com/openshift/cluster-kube-descheduler-operator/pkg/generated/clientset/versioned/typed/descheduler/v1"
 	discovery "k8s.io/client-go/discovery"

--- a/pkg/generated/clientset/versioned/typed/descheduler/v1/descheduler_client.go
+++ b/pkg/generated/clientset/versioned/typed/descheduler/v1/descheduler_client.go
@@ -3,10 +3,10 @@
 package v1
 
 import (
-	"net/http"
+	http "net/http"
 
-	v1 "github.com/openshift/cluster-kube-descheduler-operator/pkg/apis/descheduler/v1"
-	"github.com/openshift/cluster-kube-descheduler-operator/pkg/generated/clientset/versioned/scheme"
+	deschedulerv1 "github.com/openshift/cluster-kube-descheduler-operator/pkg/apis/descheduler/v1"
+	scheme "github.com/openshift/cluster-kube-descheduler-operator/pkg/generated/clientset/versioned/scheme"
 	rest "k8s.io/client-go/rest"
 )
 
@@ -69,10 +69,10 @@ func New(c rest.Interface) *KubedeschedulersV1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1.SchemeGroupVersion
+	gv := deschedulerv1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	config.NegotiatedSerializer = rest.CodecFactoryForGeneratedClient(scheme.Scheme, scheme.Codecs).WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/pkg/generated/clientset/versioned/typed/descheduler/v1/fake/fake_descheduler_client.go
+++ b/pkg/generated/clientset/versioned/typed/descheduler/v1/fake/fake_descheduler_client.go
@@ -13,7 +13,7 @@ type FakeKubedeschedulersV1 struct {
 }
 
 func (c *FakeKubedeschedulersV1) KubeDeschedulers(namespace string) v1.KubeDeschedulerInterface {
-	return &FakeKubeDeschedulers{c, namespace}
+	return newFakeKubeDeschedulers(c, namespace)
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/pkg/generated/clientset/versioned/typed/descheduler/v1/kubedescheduler.go
+++ b/pkg/generated/clientset/versioned/typed/descheduler/v1/kubedescheduler.go
@@ -3,10 +3,10 @@
 package v1
 
 import (
-	"context"
+	context "context"
 
-	v1 "github.com/openshift/cluster-kube-descheduler-operator/pkg/apis/descheduler/v1"
-	deschedulerv1 "github.com/openshift/cluster-kube-descheduler-operator/pkg/generated/applyconfiguration/descheduler/v1"
+	deschedulerv1 "github.com/openshift/cluster-kube-descheduler-operator/pkg/apis/descheduler/v1"
+	applyconfigurationdeschedulerv1 "github.com/openshift/cluster-kube-descheduler-operator/pkg/generated/applyconfiguration/descheduler/v1"
 	scheme "github.com/openshift/cluster-kube-descheduler-operator/pkg/generated/clientset/versioned/scheme"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -22,36 +22,37 @@ type KubeDeschedulersGetter interface {
 
 // KubeDeschedulerInterface has methods to work with KubeDescheduler resources.
 type KubeDeschedulerInterface interface {
-	Create(ctx context.Context, kubeDescheduler *v1.KubeDescheduler, opts metav1.CreateOptions) (*v1.KubeDescheduler, error)
-	Update(ctx context.Context, kubeDescheduler *v1.KubeDescheduler, opts metav1.UpdateOptions) (*v1.KubeDescheduler, error)
+	Create(ctx context.Context, kubeDescheduler *deschedulerv1.KubeDescheduler, opts metav1.CreateOptions) (*deschedulerv1.KubeDescheduler, error)
+	Update(ctx context.Context, kubeDescheduler *deschedulerv1.KubeDescheduler, opts metav1.UpdateOptions) (*deschedulerv1.KubeDescheduler, error)
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-	UpdateStatus(ctx context.Context, kubeDescheduler *v1.KubeDescheduler, opts metav1.UpdateOptions) (*v1.KubeDescheduler, error)
+	UpdateStatus(ctx context.Context, kubeDescheduler *deschedulerv1.KubeDescheduler, opts metav1.UpdateOptions) (*deschedulerv1.KubeDescheduler, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
-	Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1.KubeDescheduler, error)
-	List(ctx context.Context, opts metav1.ListOptions) (*v1.KubeDeschedulerList, error)
+	Get(ctx context.Context, name string, opts metav1.GetOptions) (*deschedulerv1.KubeDescheduler, error)
+	List(ctx context.Context, opts metav1.ListOptions) (*deschedulerv1.KubeDeschedulerList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.KubeDescheduler, err error)
-	Apply(ctx context.Context, kubeDescheduler *deschedulerv1.KubeDeschedulerApplyConfiguration, opts metav1.ApplyOptions) (result *v1.KubeDescheduler, err error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *deschedulerv1.KubeDescheduler, err error)
+	Apply(ctx context.Context, kubeDescheduler *applyconfigurationdeschedulerv1.KubeDeschedulerApplyConfiguration, opts metav1.ApplyOptions) (result *deschedulerv1.KubeDescheduler, err error)
 	// Add a +genclient:noStatus comment above the type to avoid generating ApplyStatus().
-	ApplyStatus(ctx context.Context, kubeDescheduler *deschedulerv1.KubeDeschedulerApplyConfiguration, opts metav1.ApplyOptions) (result *v1.KubeDescheduler, err error)
+	ApplyStatus(ctx context.Context, kubeDescheduler *applyconfigurationdeschedulerv1.KubeDeschedulerApplyConfiguration, opts metav1.ApplyOptions) (result *deschedulerv1.KubeDescheduler, err error)
 	KubeDeschedulerExpansion
 }
 
 // kubeDeschedulers implements KubeDeschedulerInterface
 type kubeDeschedulers struct {
-	*gentype.ClientWithListAndApply[*v1.KubeDescheduler, *v1.KubeDeschedulerList, *deschedulerv1.KubeDeschedulerApplyConfiguration]
+	*gentype.ClientWithListAndApply[*deschedulerv1.KubeDescheduler, *deschedulerv1.KubeDeschedulerList, *applyconfigurationdeschedulerv1.KubeDeschedulerApplyConfiguration]
 }
 
 // newKubeDeschedulers returns a KubeDeschedulers
 func newKubeDeschedulers(c *KubedeschedulersV1Client, namespace string) *kubeDeschedulers {
 	return &kubeDeschedulers{
-		gentype.NewClientWithListAndApply[*v1.KubeDescheduler, *v1.KubeDeschedulerList, *deschedulerv1.KubeDeschedulerApplyConfiguration](
+		gentype.NewClientWithListAndApply[*deschedulerv1.KubeDescheduler, *deschedulerv1.KubeDeschedulerList, *applyconfigurationdeschedulerv1.KubeDeschedulerApplyConfiguration](
 			"kubedeschedulers",
 			c.RESTClient(),
 			scheme.ParameterCodec,
 			namespace,
-			func() *v1.KubeDescheduler { return &v1.KubeDescheduler{} },
-			func() *v1.KubeDeschedulerList { return &v1.KubeDeschedulerList{} }),
+			func() *deschedulerv1.KubeDescheduler { return &deschedulerv1.KubeDescheduler{} },
+			func() *deschedulerv1.KubeDeschedulerList { return &deschedulerv1.KubeDeschedulerList{} },
+		),
 	}
 }

--- a/pkg/generated/informers/externalversions/descheduler/v1/kubedescheduler.go
+++ b/pkg/generated/informers/externalversions/descheduler/v1/kubedescheduler.go
@@ -3,13 +3,13 @@
 package v1
 
 import (
-	"context"
+	context "context"
 	time "time"
 
-	deschedulerv1 "github.com/openshift/cluster-kube-descheduler-operator/pkg/apis/descheduler/v1"
+	apisdeschedulerv1 "github.com/openshift/cluster-kube-descheduler-operator/pkg/apis/descheduler/v1"
 	versioned "github.com/openshift/cluster-kube-descheduler-operator/pkg/generated/clientset/versioned"
 	internalinterfaces "github.com/openshift/cluster-kube-descheduler-operator/pkg/generated/informers/externalversions/internalinterfaces"
-	v1 "github.com/openshift/cluster-kube-descheduler-operator/pkg/generated/listers/descheduler/v1"
+	deschedulerv1 "github.com/openshift/cluster-kube-descheduler-operator/pkg/generated/listers/descheduler/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -20,7 +20,7 @@ import (
 // KubeDeschedulers.
 type KubeDeschedulerInformer interface {
 	Informer() cache.SharedIndexInformer
-	Lister() v1.KubeDeschedulerLister
+	Lister() deschedulerv1.KubeDeschedulerLister
 }
 
 type kubeDeschedulerInformer struct {
@@ -55,7 +55,7 @@ func NewFilteredKubeDeschedulerInformer(client versioned.Interface, namespace st
 				return client.KubedeschedulersV1().KubeDeschedulers(namespace).Watch(context.TODO(), options)
 			},
 		},
-		&deschedulerv1.KubeDescheduler{},
+		&apisdeschedulerv1.KubeDescheduler{},
 		resyncPeriod,
 		indexers,
 	)
@@ -66,9 +66,9 @@ func (f *kubeDeschedulerInformer) defaultInformer(client versioned.Interface, re
 }
 
 func (f *kubeDeschedulerInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&deschedulerv1.KubeDescheduler{}, f.defaultInformer)
+	return f.factory.InformerFor(&apisdeschedulerv1.KubeDescheduler{}, f.defaultInformer)
 }
 
-func (f *kubeDeschedulerInformer) Lister() v1.KubeDeschedulerLister {
-	return v1.NewKubeDeschedulerLister(f.Informer().GetIndexer())
+func (f *kubeDeschedulerInformer) Lister() deschedulerv1.KubeDeschedulerLister {
+	return deschedulerv1.NewKubeDeschedulerLister(f.Informer().GetIndexer())
 }

--- a/pkg/generated/informers/externalversions/generic.go
+++ b/pkg/generated/informers/externalversions/generic.go
@@ -3,7 +3,7 @@
 package externalversions
 
 import (
-	"fmt"
+	fmt "fmt"
 
 	v1 "github.com/openshift/cluster-kube-descheduler-operator/pkg/apis/descheduler/v1"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/generated/listers/descheduler/v1/kubedescheduler.go
+++ b/pkg/generated/listers/descheduler/v1/kubedescheduler.go
@@ -3,10 +3,10 @@
 package v1
 
 import (
-	v1 "github.com/openshift/cluster-kube-descheduler-operator/pkg/apis/descheduler/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/listers"
-	"k8s.io/client-go/tools/cache"
+	deschedulerv1 "github.com/openshift/cluster-kube-descheduler-operator/pkg/apis/descheduler/v1"
+	labels "k8s.io/apimachinery/pkg/labels"
+	listers "k8s.io/client-go/listers"
+	cache "k8s.io/client-go/tools/cache"
 )
 
 // KubeDeschedulerLister helps list KubeDeschedulers.
@@ -14,7 +14,7 @@ import (
 type KubeDeschedulerLister interface {
 	// List lists all KubeDeschedulers in the indexer.
 	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1.KubeDescheduler, err error)
+	List(selector labels.Selector) (ret []*deschedulerv1.KubeDescheduler, err error)
 	// KubeDeschedulers returns an object that can list and get KubeDeschedulers.
 	KubeDeschedulers(namespace string) KubeDeschedulerNamespaceLister
 	KubeDeschedulerListerExpansion
@@ -22,17 +22,17 @@ type KubeDeschedulerLister interface {
 
 // kubeDeschedulerLister implements the KubeDeschedulerLister interface.
 type kubeDeschedulerLister struct {
-	listers.ResourceIndexer[*v1.KubeDescheduler]
+	listers.ResourceIndexer[*deschedulerv1.KubeDescheduler]
 }
 
 // NewKubeDeschedulerLister returns a new KubeDeschedulerLister.
 func NewKubeDeschedulerLister(indexer cache.Indexer) KubeDeschedulerLister {
-	return &kubeDeschedulerLister{listers.New[*v1.KubeDescheduler](indexer, v1.Resource("kubedescheduler"))}
+	return &kubeDeschedulerLister{listers.New[*deschedulerv1.KubeDescheduler](indexer, deschedulerv1.Resource("kubedescheduler"))}
 }
 
 // KubeDeschedulers returns an object that can list and get KubeDeschedulers.
 func (s *kubeDeschedulerLister) KubeDeschedulers(namespace string) KubeDeschedulerNamespaceLister {
-	return kubeDeschedulerNamespaceLister{listers.NewNamespaced[*v1.KubeDescheduler](s.ResourceIndexer, namespace)}
+	return kubeDeschedulerNamespaceLister{listers.NewNamespaced[*deschedulerv1.KubeDescheduler](s.ResourceIndexer, namespace)}
 }
 
 // KubeDeschedulerNamespaceLister helps list and get KubeDeschedulers.
@@ -40,15 +40,15 @@ func (s *kubeDeschedulerLister) KubeDeschedulers(namespace string) KubeDeschedul
 type KubeDeschedulerNamespaceLister interface {
 	// List lists all KubeDeschedulers in the indexer for a given namespace.
 	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1.KubeDescheduler, err error)
+	List(selector labels.Selector) (ret []*deschedulerv1.KubeDescheduler, err error)
 	// Get retrieves the KubeDescheduler from the indexer for a given namespace and name.
 	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1.KubeDescheduler, error)
+	Get(name string) (*deschedulerv1.KubeDescheduler, error)
 	KubeDeschedulerNamespaceListerExpansion
 }
 
 // kubeDeschedulerNamespaceLister implements the KubeDeschedulerNamespaceLister
 // interface.
 type kubeDeschedulerNamespaceLister struct {
-	listers.ResourceIndexer[*v1.KubeDescheduler]
+	listers.ResourceIndexer[*deschedulerv1.KubeDescheduler]
 }


### PR DESCRIPTION
TODO:
* https://github.com/kubernetes-sigs/descheduler/pull/1642 (lownodeutilization: evictionLimits to limit the evictions per plugin): this needs to be merged upstream
* https://github.com/kubernetes-sigs/descheduler/pull/1533 ([lownodeutilization]: Actual utilization: integration with Prometheus): this needs to be refactored and merged upstream
* https://github.com/openshift/enhancements/pull/1760: needs to be reviewed, approved and merged
* https://github.com/openshift/cluster-kube-descheduler-operator/pull/448 (WIP: Add soft tainter controller): needs to be merged so it can be deployed alongside the descheduler deployment
* Reconciling a new SA and ValidatingAdmissionPolicy 