### PR TITLE
OCPBUGS-54414: Lownodeutilization fall back to protected namespaces when ns inclusion

### DIFF
--- a/pkg/operator/target_config_reconciler_test.go
+++ b/pkg/operator/target_config_reconciler_test.go
@@ -128,6 +128,24 @@ func TestManageConfigMap(t *testing.T) {
 			err: fmt.Errorf("It is invalid to set both .spec.profileCustomizations.thresholdPriority and .spec.profileCustomizations.ThresholdPriorityClassName fields"),
 		},
 		{
+			name: "LowNodeUtilizationIncludedNamespace",
+			descheduler: &deschedulerv1.KubeDescheduler{
+				Spec: deschedulerv1.KubeDeschedulerSpec{
+					Profiles: []deschedulerv1.DeschedulerProfile{"LifecycleAndUtilization"},
+					ProfileCustomizations: &deschedulerv1.ProfileCustomizations{
+						DevLowNodeUtilizationThresholds: &deschedulerv1.LowThreshold,
+						Namespaces: deschedulerv1.Namespaces{
+							Included: []string{"includedNamespace"},
+						},
+					},
+				},
+			},
+			want: &corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+				Data:     map[string]string{"policy.yaml": string(bindata.MustAsset("assets/lowNodeUtilizationIncludedNamespace.yaml"))},
+			},
+		},
+		{
 			name: "LowNodeUtilizationLow",
 			descheduler: &deschedulerv1.KubeDescheduler{
 				Spec: deschedulerv1.KubeDeschedulerSpec{

--- a/pkg/operator/testdata/assets/lowNodeUtilizationIncludedNamespace.yaml
+++ b/pkg/operator/testdata/assets/lowNodeUtilizationIncludedNamespace.yaml
@@ -2,8 +2,14 @@ apiVersion: descheduler/v1alpha2
 kind: DeschedulerPolicy
 metricsCollector: {}
 profiles:
-- name: LongLifecycle
+- name: LifecycleAndUtilization
   pluginConfig:
+  - args:
+      maxPodLifeTimeSeconds: 86400
+      namespaces:
+        include:
+        - includedNamespace
+    name: PodLifeTime
   - args:
       includingInitContainers: true
       namespaces:
@@ -21,13 +27,13 @@ profiles:
       metricsUtilization:
         prometheus: {}
       targetThresholds:
-        cpu: 50
-        memory: 50
-        pods: 50
+        cpu: 30
+        memory: 30
+        pods: 30
       thresholds:
-        cpu: 20
-        memory: 20
-        pods: 20
+        cpu: 10
+        memory: 10
+        pods: 10
     name: LowNodeUtilization
   - args:
       ignorePvcPods: true
@@ -40,6 +46,7 @@ profiles:
     deschedule:
       disabled: null
       enabled:
+      - PodLifeTime
       - RemovePodsHavingTooManyRestarts
     filter:
       disabled: null


### PR DESCRIPTION
LowNodeUtilization does not support namespace inclusion. Thus, the list of excluded namespace needs to fall back to the list of protected namespace instead of not setting ommiting the namespace inclusion.
