### PR TITLE
CNTRLPLANE-260: devKubeVirtRelieveAndMigrate: enable EvictPodsWithPVC and EvictPodsWithLocalStorage by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,10 @@ Migration strategies may involve VM live migration, state transitions between st
 
 This profile enables the [`LowNodeUtilization`](https://github.com/kubernetes-sigs/descheduler/#lownodeutilization) strategy
 with `EvictionsInBackground` alpha feature enabled.
-In the future, more configuration may be made available through the operator based on user feedback.
+At the same time, allow the eviction of pods with PVC or local storage (both disabled by default),
+as they are commonly encountered during VM eviction and migration.
+Equivalent to enabling both `EvictPodsWithPVC` and `EvictPodsWithLocalStorage` profiles in parallel.
+In the future, additional configurations may be introduced through the operator based on user feedback.
 
 The profile exposes the following customization:
 - `devLowNodeUtilizationThresholds`: Sets experimental thresholds for the LowNodeUtilization strategy.

--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -730,7 +730,7 @@ func lifecycleAndUtilizationProfile(profileCustomizations *deschedulerv1.Profile
 	return profile, nil
 }
 
-func relieveAndMigrateProfile(profileCustomizations *deschedulerv1.ProfileCustomizations, includedNamespaces, excludedNamespaces, protectedNamespaces []string, ignorePVCPods, evictLocalStoragePods bool) (*v1alpha2.DeschedulerProfile, error) {
+func relieveAndMigrateProfile(profileCustomizations *deschedulerv1.ProfileCustomizations, includedNamespaces, excludedNamespaces, protectedNamespaces []string) (*v1alpha2.DeschedulerProfile, error) {
 	profile := &v1alpha2.DeschedulerProfile{
 		Name: string(deschedulerv1.RelieveAndMigrate),
 		PluginConfigs: []v1alpha2.PluginConfig{
@@ -747,8 +747,8 @@ func relieveAndMigrateProfile(profileCustomizations *deschedulerv1.ProfileCustom
 				Name: defaultevictor.PluginName,
 				Args: runtime.RawExtension{
 					Object: &defaultevictor.DefaultEvictorArgs{
-						IgnorePvcPods:         ignorePVCPods,
-						EvictLocalStoragePods: evictLocalStoragePods,
+						IgnorePvcPods:         false, // evict pvc pods by default
+						EvictLocalStoragePods: true,  // evict pods with local storage by default
 					},
 				},
 			},
@@ -1023,7 +1023,7 @@ func (c *TargetConfigReconciler) manageConfigMap(descheduler *deschedulerv1.Kube
 		case deschedulerv1.CompactAndScale:
 			profile, err = compactAndScaleProfile(descheduler.Spec.ProfileCustomizations, includedNamespaces, excludedNamespaces, ignorePVCPods, evictLocalStoragePods)
 		case deschedulerv1.RelieveAndMigrate:
-			profile, err = relieveAndMigrateProfile(descheduler.Spec.ProfileCustomizations, includedNamespaces, excludedNamespaces, c.protectedNamespaces, ignorePVCPods, evictLocalStoragePods)
+			profile, err = relieveAndMigrateProfile(descheduler.Spec.ProfileCustomizations, includedNamespaces, excludedNamespaces, c.protectedNamespaces)
 		default:
 			err = fmt.Errorf("Profile %q not recognized", profileName)
 		}

--- a/pkg/operator/testdata/assets/relieveAndMigrateHighConfig.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateHighConfig.yaml
@@ -20,7 +20,7 @@ profiles:
         pods: 40
     name: LowNodeUtilization
   - args:
-      ignorePvcPods: true
+      evictLocalStoragePods: true
     name: DefaultEvictor
   plugins:
     balance:

--- a/pkg/operator/testdata/assets/relieveAndMigrateIncludedNamespace.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateIncludedNamespace.yaml
@@ -20,7 +20,7 @@ profiles:
         pods: 20
     name: LowNodeUtilization
   - args:
-      ignorePvcPods: true
+      evictLocalStoragePods: true
     name: DefaultEvictor
   plugins:
     balance:

--- a/pkg/operator/testdata/assets/relieveAndMigrateLowConfig.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateLowConfig.yaml
@@ -20,7 +20,7 @@ profiles:
         pods: 10
     name: LowNodeUtilization
   - args:
-      ignorePvcPods: true
+      evictLocalStoragePods: true
     name: DefaultEvictor
   plugins:
     balance:

--- a/pkg/operator/testdata/assets/relieveAndMigrateMediumConfig.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateMediumConfig.yaml
@@ -20,7 +20,7 @@ profiles:
         pods: 20
     name: LowNodeUtilization
   - args:
-      ignorePvcPods: true
+      evictLocalStoragePods: true
     name: DefaultEvictor
   plugins:
     balance:


### PR DESCRIPTION
Both profiles (eviction of pods with a PVC and a local storage) are a common kubevirt use cases.