### PR TITLE
Have the SoftTainter always deployed with KubeVirtRelieveAndMigrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,11 +174,16 @@ That nodeSelector is a top level configuration option affecting all the active d
 this profile is not expected to be combined with other profiles
 unless all profiles are expected to operate over the same set of nodes.
 
+This profile deploys the soft-tainter component to dynamically set/remove soft taints according to the
+same criteria used for load aware descheduling. In case of load-aware descheduling we can potentially have a
+relevant asymmetry between the descheduling and successive scheduling decisions.
+The soft taints set by the descheduler soft-tainter act as a hint for the scheduler to mitigate
+this asymmetry and foster a quicker convergence.
+
 The profile exposes the following customization:
 - `devLowNodeUtilizationThresholds`: Sets experimental thresholds for the LowNodeUtilization strategy.
 - `devActualUtilizationProfile`: Enable load-aware descheduling.
 - `devDeviationThresholds`: Have the thresholds be based on the average utilization.
-- `devEnableSoftTainter`: Have the operator deploying the soft-tainter component to dynamically set/remove soft taints according to the same criteria used for load aware descheduling. Scheduling and descheduling decisions are in general fully independent. In case of load-aware descheduling we can potentially have a relevant asymmetry between the descheduling and successive scheduling decisions. The soft taints set by the descheduler soft-tainter act as a hint for the scheduler to mitigate this asymmetry and foster a quicker convergence.
 
 ### EvictPodsWithPVC
 By default, the operator prevents pods with PVCs from being evicted. Enabling this
@@ -207,7 +212,6 @@ the `profileCustomizations` field:
 | `devHighNodeUtilizationThresholds` | `string` | Sets thresholds for the [HighNodeUtilization](https://github.com/kubernetes-sigs/descheduler#highnodeutilization) strategy of the `CompactAndScale` profile in the following ratios: `Minimal` for 10%, `Modest` for 20%, `Moderate` for 30%. Currently provided as an experimental feature.|
 |`devActualUtilizationProfile`|`string`| Sets a profile that gets translated into a predefined prometheus query |
 | `devDeviationThresholds` | `string` | Have the thresholds be based on the average utilization. Thresholds signify the distance from the average node utilization. An AsymmetricDeviationThreshold will force all nodes below the average to be considered as underutilized to help rebalancing overutilized outliers. Supported settings: `Low`: 10%:10%, `Medium`: 20%:20%, `High`: 30%:30%, `AsymmetricLow`: 0%:10%, `AsymmetricMedium`: 0%:20%, `AsymmetricHigh`: 0%:30% |
-| `devEnableSoftTainter` | `bool` | Have the operator deploying the soft-tainter component to dynamic set/remove soft taints as a hint for the scheduler based on the same criteria used for the descheduling |
 
 ## Prometheus query profiles
 The operator provides the following profiles:

--- a/manifests/kube-descheduler-operator.crd.yaml
+++ b/manifests/kube-descheduler-operator.crd.yaml
@@ -133,6 +133,7 @@ spec:
                       DevEnableSoftTainter enables SoftTainter alpha feature.
                       The EnableSoftTainter alpha feature is a subject to change.
                       Currently provided as an experimental feature.
+                      Deprecated: DevEnableSoftTainter field is deprecated and ignored.
                     type: boolean
                   devHighNodeUtilizationThresholds:
                     description: |-

--- a/pkg/apis/descheduler/v1/types_descheduler.go
+++ b/pkg/apis/descheduler/v1/types_descheduler.go
@@ -78,6 +78,8 @@ type ProfileCustomizations struct {
 	// DevEnableSoftTainter enables SoftTainter alpha feature.
 	// The EnableSoftTainter alpha feature is a subject to change.
 	// Currently provided as an experimental feature.
+	// +kubebuilder:deprecatedversion:warning="devEnableSoftTainter field is deprecated and ignored"
+	// Deprecated: DevEnableSoftTainter field is deprecated and ignored.
 	DevEnableSoftTainter bool `json:"devEnableSoftTainter"`
 
 	// DevEnableEvictionsInBackground enables descheduler's EvictionsInBackground alpha feature.

--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -1255,12 +1255,6 @@ func (c *TargetConfigReconciler) manageConfigMap(descheduler *deschedulerv1.Kube
 		}
 	}
 
-	if descheduler.Spec.ProfileCustomizations != nil && descheduler.Spec.ProfileCustomizations.DevEnableSoftTainter {
-		if !slices.Contains(descheduler.Spec.Profiles, deschedulerv1.RelieveAndMigrate) {
-			return nil, true, fmt.Errorf("the softtainter can only be used with the %v profile", deschedulerv1.RelieveAndMigrate)
-		}
-	}
-
 	// ignore PVC pods by default
 	ignorePVCPods := true
 	evictLocalStoragePods := false
@@ -1596,9 +1590,10 @@ func (c *TargetConfigReconciler) isKubeVirtDeployed() (bool, error) {
 }
 
 func (c *TargetConfigReconciler) isSoftTainterNeeded(descheduler *deschedulerv1.KubeDescheduler) (bool, error) {
-	if descheduler.Spec.ProfileCustomizations != nil && descheduler.Spec.ProfileCustomizations.DevEnableSoftTainter {
+	if slices.Contains(descheduler.Spec.Profiles, deschedulerv1.RelieveAndMigrate) {
 		return true, nil
 	}
+
 	ls, err := labels.Parse(kubeVirtShedulableLabelSelector)
 	if err != nil {
 		return false, err

--- a/pkg/operator/target_config_reconciler_test.go
+++ b/pkg/operator/target_config_reconciler_test.go
@@ -1170,14 +1170,13 @@ func TestManageSoftTainterDeployment(t *testing.T) {
 		checkContainerArgsOnly bool
 	}{
 		{
-			name: "RelieveAndMigrate with the softtainer",
+			name: "RelieveAndMigrate",
 			descheduler: &deschedulerv1.KubeDescheduler{
 				Spec: deschedulerv1.KubeDeschedulerSpec{
 					Profiles: []deschedulerv1.DeschedulerProfile{deschedulerv1.RelieveAndMigrate},
 					ProfileCustomizations: &deschedulerv1.ProfileCustomizations{
 						DevDeviationThresholds:      &deschedulerv1.LowDeviationThreshold,
 						DevActualUtilizationProfile: deschedulerv1.PrometheusCPUCombinedProfile,
-						DevEnableSoftTainter:        true,
 					},
 					DeschedulingIntervalSeconds: utilptr.To[int32](10),
 				},
@@ -1187,14 +1186,13 @@ func TestManageSoftTainterDeployment(t *testing.T) {
 			want:                   expectedSoftTainterDeployment,
 		},
 		{
-			name: "RelieveAndMigrate without the softtainer and no leftovers on existing nodes",
+			name: "LifecycleAndUtilization (without the softtainer) and no leftovers on existing nodes",
 			descheduler: &deschedulerv1.KubeDescheduler{
 				Spec: deschedulerv1.KubeDeschedulerSpec{
-					Profiles: []deschedulerv1.DeschedulerProfile{deschedulerv1.RelieveAndMigrate},
+					Profiles: []deschedulerv1.DeschedulerProfile{deschedulerv1.LifecycleAndUtilization},
 					ProfileCustomizations: &deschedulerv1.ProfileCustomizations{
 						DevDeviationThresholds:      &deschedulerv1.LowDeviationThreshold,
 						DevActualUtilizationProfile: deschedulerv1.PrometheusCPUCombinedProfile,
-						DevEnableSoftTainter:        false,
 					},
 					DeschedulingIntervalSeconds: utilptr.To[int32](10),
 				},
@@ -1234,14 +1232,13 @@ func TestManageSoftTainterDeployment(t *testing.T) {
 			want:                   nil,
 		},
 		{
-			name: "RelieveAndMigrate without the softtainer but a leftover on existing nodes - 1",
+			name: "LifecycleAndUtilization (without the softtainer) but a leftover on existing nodes - 1",
 			descheduler: &deschedulerv1.KubeDescheduler{
 				Spec: deschedulerv1.KubeDeschedulerSpec{
-					Profiles: []deschedulerv1.DeschedulerProfile{deschedulerv1.RelieveAndMigrate},
+					Profiles: []deschedulerv1.DeschedulerProfile{deschedulerv1.LifecycleAndUtilization},
 					ProfileCustomizations: &deschedulerv1.ProfileCustomizations{
 						DevDeviationThresholds:      &deschedulerv1.LowDeviationThreshold,
 						DevActualUtilizationProfile: deschedulerv1.PrometheusCPUCombinedProfile,
-						DevEnableSoftTainter:        false,
 					},
 					DeschedulingIntervalSeconds: utilptr.To[int32](10),
 				},
@@ -1276,14 +1273,13 @@ func TestManageSoftTainterDeployment(t *testing.T) {
 			want:                   expectedSoftTainterDeployment,
 		},
 		{
-			name: "RelieveAndMigrate without the softtainer but a leftover on existing nodes - 2",
+			name: "LifecycleAndUtilization (without the softtainer) but a leftover on existing nodes - 2",
 			descheduler: &deschedulerv1.KubeDescheduler{
 				Spec: deschedulerv1.KubeDeschedulerSpec{
-					Profiles: []deschedulerv1.DeschedulerProfile{deschedulerv1.RelieveAndMigrate},
+					Profiles: []deschedulerv1.DeschedulerProfile{deschedulerv1.LifecycleAndUtilization},
 					ProfileCustomizations: &deschedulerv1.ProfileCustomizations{
 						DevDeviationThresholds:      &deschedulerv1.LowDeviationThreshold,
 						DevActualUtilizationProfile: deschedulerv1.PrometheusCPUCombinedProfile,
-						DevEnableSoftTainter:        false,
 					},
 					DeschedulingIntervalSeconds: utilptr.To[int32](10),
 				},

--- a/pkg/softtainter/softtainter_test.go
+++ b/pkg/softtainter/softtainter_test.go
@@ -109,7 +109,6 @@ func TestReconcile(t *testing.T) {
 					DeschedulingIntervalSeconds: pointer.Int32(30),
 					Mode:                        deschedulerv1.Automatic,
 					ProfileCustomizations: &deschedulerv1.ProfileCustomizations{
-						DevEnableSoftTainter:   true,
 						DevDeviationThresholds: &deschedulerv1.LowDeviationThreshold,
 					},
 				},
@@ -146,7 +145,6 @@ func TestReconcile(t *testing.T) {
 					DeschedulingIntervalSeconds: pointer.Int32(30),
 					Mode:                        deschedulerv1.Automatic,
 					ProfileCustomizations: &deschedulerv1.ProfileCustomizations{
-						DevEnableSoftTainter:   true,
 						DevDeviationThresholds: &deschedulerv1.LowDeviationThreshold,
 					},
 				},
@@ -183,7 +181,6 @@ func TestReconcile(t *testing.T) {
 					DeschedulingIntervalSeconds: pointer.Int32(30),
 					Mode:                        deschedulerv1.Automatic,
 					ProfileCustomizations: &deschedulerv1.ProfileCustomizations{
-						DevEnableSoftTainter:   true,
 						DevDeviationThresholds: &deschedulerv1.LowDeviationThreshold,
 					},
 				},
@@ -226,7 +223,6 @@ func TestReconcile(t *testing.T) {
 					DeschedulingIntervalSeconds: pointer.Int32(30),
 					Mode:                        deschedulerv1.Automatic,
 					ProfileCustomizations: &deschedulerv1.ProfileCustomizations{
-						DevEnableSoftTainter:   true,
 						DevDeviationThresholds: &deschedulerv1.LowDeviationThreshold,
 					},
 				},
@@ -263,7 +259,6 @@ func TestReconcile(t *testing.T) {
 					DeschedulingIntervalSeconds: pointer.Int32(30),
 					Mode:                        deschedulerv1.Automatic,
 					ProfileCustomizations: &deschedulerv1.ProfileCustomizations{
-						DevEnableSoftTainter:   true,
 						DevDeviationThresholds: &deschedulerv1.LowDeviationThreshold,
 					},
 				},
@@ -300,7 +295,6 @@ func TestReconcile(t *testing.T) {
 					DeschedulingIntervalSeconds: pointer.Int32(30),
 					Mode:                        deschedulerv1.Automatic,
 					ProfileCustomizations: &deschedulerv1.ProfileCustomizations{
-						DevEnableSoftTainter:   true,
 						DevDeviationThresholds: &deschedulerv1.LowDeviationThreshold,
 					},
 				},
@@ -308,7 +302,7 @@ func TestReconcile(t *testing.T) {
 			testfilename: "policy.yaml",
 		},
 		{
-			description: "3 nodes, softTainter is disabled",
+			description: "3 nodes, RelieveAndMigrate is disabled",
 			nodes: []*corev1.Node{
 				buildTestNodeWithTaints("node1", true, false, false, true),
 				buildTestNodeWithTaints("node2", true, false, false, true),
@@ -337,15 +331,14 @@ func TestReconcile(t *testing.T) {
 					DeschedulingIntervalSeconds: pointer.Int32(30),
 					Mode:                        deschedulerv1.Automatic,
 					ProfileCustomizations: &deschedulerv1.ProfileCustomizations{
-						DevEnableSoftTainter:   false,
 						DevDeviationThresholds: &deschedulerv1.LowDeviationThreshold,
 					},
 				},
 			},
-			testfilename: "policy.yaml",
+			testfilename: "policyNoRelieveAndMigrate.yaml",
 		},
 		{
-			description: "3 nodes, softTainter is disabled, leftover taints",
+			description: "3 nodes, RelieveAndMigrate is disabled, leftover taints",
 			nodes: []*corev1.Node{
 				buildTestNodeWithTaints("node1", true, true, false, true),
 				buildTestNodeWithTaints("node2", true, false, true, true),
@@ -374,12 +367,11 @@ func TestReconcile(t *testing.T) {
 					DeschedulingIntervalSeconds: pointer.Int32(30),
 					Mode:                        deschedulerv1.Automatic,
 					ProfileCustomizations: &deschedulerv1.ProfileCustomizations{
-						DevEnableSoftTainter:   false,
 						DevDeviationThresholds: &deschedulerv1.LowDeviationThreshold,
 					},
 				},
 			},
-			testfilename: "policy.yaml",
+			testfilename: "policyNoRelieveAndMigrate.yaml",
 		},
 	}
 	for _, tc := range tests {

--- a/pkg/softtainter/testdata/policyNoRelieveAndMigrate.yaml
+++ b/pkg/softtainter/testdata/policyNoRelieveAndMigrate.yaml
@@ -1,0 +1,52 @@
+apiVersion: descheduler/v1alpha2
+kind: DeschedulerPolicy
+metricsProviders:
+  - prometheus:
+      url: https://prometheus-k8s-openshift-monitoring.apps.example.com
+    source: Prometheus
+nodeSelector: kubevirt.io/schedulable=true
+profiles:
+  - name: LifecycleAndUtilization
+    pluginConfig:
+      - args:
+          evictableNamespaces:
+            exclude:
+              - kube-system
+              - hypershift
+              - openshift
+              - openshift-kube-descheduler-operator
+              - openshift-kube-scheduler
+          metricsUtilization:
+            prometheus:
+              query: descheduler:combined_utilization_and_pressure:avg1m
+            source: Prometheus
+          targetThresholds:
+            MetricResource: 10
+          thresholds:
+            MetricResource: 10
+          useDeviationThresholds: true
+        name: LowNodeUtilization
+      - args:
+          evictLocalStoragePods: true
+        name: DefaultEvictor
+    plugins:
+      balance:
+        disabled: null
+        enabled:
+          - LowNodeUtilization
+      deschedule:
+        disabled: null
+        enabled: null
+      filter:
+        disabled: null
+        enabled:
+          - DefaultEvictor
+      preevictionfilter:
+        disabled: null
+        enabled: null
+      presort:
+        disabled: null
+        enabled: null
+      sort:
+        disabled: null
+        enabled: null

--- a/test/e2e/bindata/assets/00_kube-descheduler-operator-crd.yaml
+++ b/test/e2e/bindata/assets/00_kube-descheduler-operator-crd.yaml
@@ -133,6 +133,7 @@ spec:
                       DevEnableSoftTainter enables SoftTainter alpha feature.
                       The EnableSoftTainter alpha feature is a subject to change.
                       Currently provided as an experimental feature.
+                      Deprecated: DevEnableSoftTainter field is deprecated and ignored.
                     type: boolean
                   devHighNodeUtilizationThresholds:
                     description: |-

--- a/test/e2e/bindata/assets/07_descheduler-operator.cr.devKubeVirtRelieveAndMigrate.yaml
+++ b/test/e2e/bindata/assets/07_descheduler-operator.cr.devKubeVirtRelieveAndMigrate.yaml
@@ -11,7 +11,6 @@ spec:
     - DevKubeVirtRelieveAndMigrate
   profileCustomizations:
     podLifetime: 10s
-    devEnableSoftTainter: true
     namespaces:
       included:
       - e2e-testdescheduling


### PR DESCRIPTION
The SoftTainter is a critical mandatory
component for the correct behaviour of the
KubeVirtRelieveAndMigrate profile.
Have it always deployed when KubeVirtRelieveAndMigrate
is in use.
Deprecate DevEnableSoftTainter.

Fixes: https://issues.redhat.com/browse/WRKLDS-1673