### PR TITLE
Add an alert and an condition for RelieveAndMigrate without PSI

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ relevant asymmetry between the descheduling and successive scheduling decisions.
 The soft taints set by the descheduler soft-tainter act as a hint for the scheduler to mitigate
 this asymmetry and foster a quicker convergence.
 
+This profile requires [PSI](https://docs.kernel.org/accounting/psi.html) metrics to be enabled (psi=1 kernel parameter)
+for all the worker nodes.
+
 The profile exposes the following customization:
 - `devLowNodeUtilizationThresholds`: Sets experimental thresholds for the LowNodeUtilization strategy.
 - `devActualUtilizationProfile`: Enable load-aware descheduling.

--- a/bindata/assets/kube-descheduler/psialert.yaml
+++ b/bindata/assets/kube-descheduler/psialert.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: descheduler-psi-alert
+  namespace: openshift-kube-descheduler-operator
+spec:
+  groups:
+    - name: recordingRules.alerts
+      rules:
+        - alert: DeschedulerPSIDisabled
+          expr: |-
+            count(kube_node_role{role="worker"}) > 
+            (count(
+              descheduler:nodepressure:cpu:avg1m * on (instance) group_left (node) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) 
+              OR on() vector(0)
+            )
+          for: 0m
+          labels:
+            severity: critical
+          annotations:
+            summary: Kube Descheduler Operator is configured to consume a PSI metric but PSI is not enabled
+            description: "Kube Descheduler Operator is configured (devActualUtilizationProfile) to consume a PSI metric but PSI is not enabled for all the worker nodes (psi=1 kernel argument)"


### PR DESCRIPTION
RelieveAndMigrate profile requires PSI metric to be enabled for the worker nodes (psi=1 kernel parameter). Directly check it for the node that is executing the operator pod, looking if /proc/pressure/ is available inside the pod, and report it with a condition.
Check it for all the worker nodes and report it also with an alert.

Fixes: https://issues.redhat.com/browse/WRKLDS-1673