### PR TITLE
BUG: ignore IsNotFound error when trying to scale down deployment

### DIFF
--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -35,6 +35,7 @@ import (
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -176,7 +177,7 @@ func (c TargetConfigReconciler) sync() error {
 					},
 				},
 				metav1.UpdateOptions{})
-			if err != nil {
+			if err != nil && !errors.IsNotFound(err) {
 				return err
 			}
 			_, _, err = v1helpers.UpdateStatus(c.ctx, c.deschedulerClient,


### PR DESCRIPTION
We can safely ignore IsNotFound errors when
the oeprator triyes to scale down the descheduler
deployment as the result of a bad configuration.
This could happen for instance if this is the first configuration attempt and the deployment has never been created before.
In this way the operator can continue and succefully report the error condition.