### PR TITLE
[RelieveAndMigrate] Default opt-out for virt-launcher pods

### DIFF
--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -68,6 +68,8 @@ import (
 
 const DefaultImage = "quay.io/openshift/origin-descheduler:latest"
 const kubeVirtShedulableLabelSelector = "kubevirt.io/schedulable=true"
+const kubeVirtLabelSelectorKey = "kubevirt.io"
+const kubeVirtLabelVirtLauncherPod = "virt-launcher"
 const psiPath = "/proc/pressure/"
 const EXPERIMENTAL_DISABLE_PSI_CHECK = "EXPERIMENTAL_DISABLE_PSI_CHECK"
 const defaultKVParallelMigrationsPerCluster = 5
@@ -1065,6 +1067,13 @@ func relieveAndMigrateProfile(profileCustomizations *deschedulerv1.ProfileCustom
 					Object: &defaultevictor.DefaultEvictorArgs{
 						IgnorePvcPods:         false, // evict pvc pods by default
 						EvictLocalStoragePods: true,  // evict pods with local storage by default
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{{
+								Key:      kubeVirtLabelSelectorKey,
+								Operator: metav1.LabelSelectorOpNotIn,
+								Values:   []string{kubeVirtLabelVirtLauncherPod},
+							}},
+						},
 					},
 				},
 			},

--- a/pkg/operator/testdata/assets/relieveAndMigrateDefaults.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateDefaults.yaml
@@ -30,6 +30,12 @@ profiles:
     name: LowNodeUtilization
   - args:
       evictLocalStoragePods: true
+      labelSelector:
+        matchExpressions:
+        - key: kubevirt.io
+          operator: NotIn
+          values:
+          - virt-launcher
     name: DefaultEvictor
   plugins:
     balance:

--- a/pkg/operator/testdata/assets/relieveAndMigrateDeviationLowWithCombinedMetrics.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateDeviationLowWithCombinedMetrics.yaml
@@ -30,6 +30,12 @@ profiles:
     name: LowNodeUtilization
   - args:
       evictLocalStoragePods: true
+      labelSelector:
+        matchExpressions:
+        - key: kubevirt.io
+          operator: NotIn
+          values:
+          - virt-launcher
     name: DefaultEvictor
   plugins:
     balance:

--- a/pkg/operator/testdata/assets/relieveAndMigrateDynamicThresholdsHigh.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateDynamicThresholdsHigh.yaml
@@ -30,6 +30,12 @@ profiles:
     name: LowNodeUtilization
   - args:
       evictLocalStoragePods: true
+      labelSelector:
+        matchExpressions:
+        - key: kubevirt.io
+          operator: NotIn
+          values:
+          - virt-launcher
     name: DefaultEvictor
   plugins:
     balance:

--- a/pkg/operator/testdata/assets/relieveAndMigrateDynamicThresholdsLow.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateDynamicThresholdsLow.yaml
@@ -30,6 +30,12 @@ profiles:
     name: LowNodeUtilization
   - args:
       evictLocalStoragePods: true
+      labelSelector:
+        matchExpressions:
+        - key: kubevirt.io
+          operator: NotIn
+          values:
+          - virt-launcher
     name: DefaultEvictor
   plugins:
     balance:

--- a/pkg/operator/testdata/assets/relieveAndMigrateDynamicThresholdsMedium.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateDynamicThresholdsMedium.yaml
@@ -30,6 +30,12 @@ profiles:
     name: LowNodeUtilization
   - args:
       evictLocalStoragePods: true
+      labelSelector:
+        matchExpressions:
+        - key: kubevirt.io
+          operator: NotIn
+          values:
+          - virt-launcher
     name: DefaultEvictor
   plugins:
     balance:

--- a/pkg/operator/testdata/assets/relieveAndMigrateEvictionLimits.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateEvictionLimits.yaml
@@ -30,6 +30,12 @@ profiles:
     name: LowNodeUtilization
   - args:
       evictLocalStoragePods: true
+      labelSelector:
+        matchExpressions:
+        - key: kubevirt.io
+          operator: NotIn
+          values:
+          - virt-launcher
     name: DefaultEvictor
   plugins:
     balance:

--- a/pkg/operator/testdata/assets/relieveAndMigrateHighConfig.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateHighConfig.yaml
@@ -29,6 +29,12 @@ profiles:
     name: LowNodeUtilization
   - args:
       evictLocalStoragePods: true
+      labelSelector:
+        matchExpressions:
+        - key: kubevirt.io
+          operator: NotIn
+          values:
+          - virt-launcher
     name: DefaultEvictor
   plugins:
     balance:

--- a/pkg/operator/testdata/assets/relieveAndMigrateIncludedNamespace.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateIncludedNamespace.yaml
@@ -30,6 +30,12 @@ profiles:
     name: LowNodeUtilization
   - args:
       evictLocalStoragePods: true
+      labelSelector:
+        matchExpressions:
+        - key: kubevirt.io
+          operator: NotIn
+          values:
+          - virt-launcher
     name: DefaultEvictor
   plugins:
     balance:

--- a/pkg/operator/testdata/assets/relieveAndMigrateLowConfig.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateLowConfig.yaml
@@ -29,6 +29,12 @@ profiles:
     name: LowNodeUtilization
   - args:
       evictLocalStoragePods: true
+      labelSelector:
+        matchExpressions:
+        - key: kubevirt.io
+          operator: NotIn
+          values:
+          - virt-launcher
     name: DefaultEvictor
   plugins:
     balance:

--- a/pkg/operator/testdata/assets/relieveAndMigrateMediumConfig.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateMediumConfig.yaml
@@ -29,6 +29,12 @@ profiles:
     name: LowNodeUtilization
   - args:
       evictLocalStoragePods: true
+      labelSelector:
+        matchExpressions:
+        - key: kubevirt.io
+          operator: NotIn
+          values:
+          - virt-launcher
     name: DefaultEvictor
   plugins:
     balance:


### PR DESCRIPTION
The annotation `descheduler.alpha.kubernetes.io/evict` can be added to a Pod to explicitly mark it as eligible for eviction by the descheduler.
However, the descheduler only checks for the presence of the annotation key but its value is ignored. As a result, both `descheduler.alpha.kubernetes.io/evict=true` and `descheduler.alpha.kubernetes.io/evict=false` have the same effect: the pod becomes evictable.

This behavior prevents unprivileged users from opting their pods out of descheduler actions, which could otherwise defeat policy enforcement.
E.g: plugins that evict pods not complying with security or organizational rules.

At the same time, the DefaultEvictor plugin allows admins to scope eviction using label selectors.
To ensure that virtual machines are not evicted unintentionally when not expected, this change makes the descheduler exclude by default all pods labeled `kubevirt.io=virt-launcher` when the `RelieveAndMigrate` plugin is enabled.

VM owners can still opt their individual VMs in or out by adding or removing the `descheduler.alpha.kubernetes.io/evict` annotation but this control is limited to virt-launcher pods (that are off by default due to the label selector), avoiding unintended effects on unrelated workloads.