### PR TITLE
OCPBUGS-62726: add CEL expression to enforce name cluster on singletons

### DIFF
--- a/manifests/kube-descheduler-operator.crd.yaml
+++ b/manifests/kube-descheduler-operator.crd.yaml
@@ -332,6 +332,10 @@ spec:
         required:
         - spec
         type: object
+        x-kubernetes-validations:
+        - fieldPath: .metadata
+          message: kubedescheduler is a singleton, .metadata.name must be 'cluster'
+          rule: self.metadata.name == 'cluster'
     served: true
     storage: true
     subresources:

--- a/pkg/apis/descheduler/v1/types_descheduler.go
+++ b/pkg/apis/descheduler/v1/types_descheduler.go
@@ -12,6 +12,7 @@ import (
 // +genclient
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
+// +kubebuilder:validation:XValidation:rule="self.metadata.name == 'cluster'",message="kubedescheduler is a singleton, .metadata.name must be 'cluster'",fieldPath=".metadata"
 type KubeDescheduler struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
See https://issues.redhat.com/browse/OCPBUGS-62726 for reference . 

### What:
+ CEL expression added to enforce `name` as `cluster` on kubedescheduler instances.

### How:
+ CEL validation expression added to `pkg/apis/descheduler/v1/types_descheduler.go` to enforce `metadata.name` == `cluster`

### Why:
+ If `name` is not `cluster`, there is no error to handle it to the user. This ensures the user knows why exactly their kubedescheduler instance did not start if the `name` was not `cluster` . 

### How to test

1. Clone [ehearne-redhat's fork](https://github.com/ehearne-redhat/cluster-kube-descheduler-operator) of this repository.
2. Change to `OCPBUGS-62726-cel-enforce-singleton-naming` branch.
3. Launch a 4.20 cluster. 
4. Log into the cluster via CLI and Console.

#### Test via Console

1. Install `Kube Descheduler Operator` from OperatorHub. You can find this in `Ecosystem` --> `Software Catalog` and then search for `kube descheduler` . 
2. Apply the manifest `manifests/kube-descheduler-operator.crd.yaml` to the cluster via the CLI --> `oc apply -f manifests/kube-descheduler-operator.crd.yaml` .
3. Try to create a Kube Descheduler Instance in the console with an invalid name. 
  a. Go to `Ecosystem` --> `Installed Operators`.
  b. Change the project to `openshift-kube-descheduler-operator`. 
  c. Click on the `Kube Descheduler Operator` .
  d. Click on the `Kube Descheduler` tab, then click on the blue `Create KubeDescheduler` button .
  e. Change the `Name` field to something other than `cluster`. E.g. `not-cluster` . Scroll to the bottom and click Create. 
  f. You should see the following error message: <img width="1340" height="278" alt="image" src="https://github.com/user-attachments/assets/bf8e37cd-1dc5-4e86-b242-41dc7ddc90c3" />
  g. Now try to create the instance using the name `cluster` . The instance should create as normal. Delete the instance and test via CLI below.

#### Test via CLI
1. Create a YAML file using [this format](https://github.com/openshift/cluster-kube-descheduler-operator?tab=readme-ov-file#sample-cr).
2. Change `.metadata.name` to something other than `cluster` . 
3. Apply the YAML file --> `oc apply -f <your yaml filename>.yaml` . 
4. You should receive the following error: `The KubeDescheduler "not-cluster" is invalid: metadata: Invalid value: "object": kubedescheduler is a singleton, .metadata.name must be 'cluster'`
5. Change `.metadata.name` to `cluster` and reapply using the same command as above.
6. You should be able to create an instance and see a message similar to: `kubedescheduler.operator.openshift.io/cluster created` . 
7. You can now shut down the cluster. 