### PR TITLE
feat(softtainter): expose node classification metrics

### DIFF
--- a/bindata/assets/kube-descheduler/softtainterdeployment.yaml
+++ b/bindata/assets/kube-descheduler/softtainterdeployment.yaml
@@ -27,7 +27,7 @@ spec:
             name: "descheduler"
         - name: certs-dir
           secret:
-            secretName: kube-descheduler-serving-cert
+            secretName: softtainter-serving-cert
       priorityClassName: "system-cluster-critical"
       restartPolicy: "Always"
       containers:
@@ -38,6 +38,10 @@ spec:
             capabilities:
               drop: ["ALL"]
           image: ${SOFTTAINTER_IMAGE}
+          ports:
+            - name: metrics
+              containerPort: 8443
+              protocol: TCP
           livenessProbe:
             failureThreshold: 1
             httpGet:

--- a/bindata/assets/kube-descheduler/softtainterservice.yaml
+++ b/bindata/assets/kube-descheduler/softtainterservice.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    service.beta.openshift.io/serving-cert-secret-name: softtainter-serving-cert
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+  labels:
+    app: softtainer
+  name: softtainter-metrics
+  namespace: openshift-kube-descheduler-operator
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app: softtainer
+  sessionAffinity: None
+  type: ClusterIP

--- a/bindata/assets/kube-descheduler/softtainterservicemonitor.yaml
+++ b/bindata/assets/kube-descheduler/softtainterservicemonitor.yaml
@@ -1,0 +1,25 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: softtainter
+  namespace: openshift-kube-descheduler-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    path: /metrics
+    port: https
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: softtainter-metrics.openshift-kube-descheduler-operator.svc
+  namespaceSelector:
+    matchNames:
+    - openshift-kube-descheduler-operator
+  selector:
+    matchLabels:
+      app: softtainer

--- a/cmd/soft-tainter/main.go
+++ b/cmd/soft-tainter/main.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	goflag "flag"
 	flag "github.com/spf13/pflag"
@@ -44,6 +45,9 @@ var (
 const (
 	HealthProbeHost             = "0.0.0.0"
 	HealthProbePort       int32 = 6060
+	MetricsHost                 = "0.0.0.0"
+	MetricsPort           int32 = 8443
+	CertsDir                    = "/certs-dir"
 	readinessEndpointName       = "/readyz"
 	livenessEndpointName        = "/livez"
 )
@@ -77,6 +81,13 @@ func getManagerOptions(operatorNamespace string, needLeaderElection bool, scheme
 		LeaderElectionNamespace:    operatorNamespace,
 		Cache:                      getCacheOption(operatorNamespace),
 		Scheme:                     scheme,
+		Metrics: metricsserver.Options{
+			BindAddress:   fmt.Sprintf("%s:%d", MetricsHost, MetricsPort),
+			SecureServing: true,
+			CertDir:       CertsDir,
+			CertName:      "tls.crt",
+			KeyName:       "tls.key",
+		},
 	}
 }
 

--- a/pkg/softtainter/metrics.go
+++ b/pkg/softtainter/metrics.go
@@ -1,0 +1,111 @@
+package softtainter
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	"sigs.k8s.io/descheduler/pkg/api"
+)
+
+const (
+	// Classification values for nodeClassification metric
+	ClassificationUnderUtilized         = 0
+	ClassificationAppropriatelyUtilized = 1
+	ClassificationOverUtilized          = 2
+)
+
+var (
+	// nodeUtilizationThreshold tracks the threshold values used for classification
+	// For static thresholds, this will be the same across all nodes
+	// For deviation-based thresholds this will vary over the time and potentially also per node
+	nodeUtilizationThreshold = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "descheduler_softtainter_node_utilization_threshold",
+			Help: "Threshold value for node utilization classification (0-1 ratio). " +
+				"For deviation-based mode, this will vary over the time and potentially also per node.",
+		},
+		[]string{
+			"node",           // Node name
+			"resource",       // Resource type (cpu, memory, etc.)
+			"threshold_type", // "low" or "high"
+		},
+	)
+
+	// nodeUtilizationValue tracks the actual utilization percentage used for classification
+	nodeUtilizationValue = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "descheduler_softtainter_node_utilization_value",
+			Help: "Actual node utilization ratio (0-1) used for classification",
+		},
+		[]string{
+			"node",     // Node name
+			"resource", // Resource type (cpu, memory, etc.)
+		},
+	)
+
+	// nodeClassification tracks the classification result for each node
+	// 0 = under-utilized, 1 = appropriately-utilized, 2 = over-utilized
+	nodeClassification = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "descheduler_softtainter_node_classification",
+			Help: "Node classification: 0=under-utilized, 1=appropriately-utilized, 2=over-utilized",
+		},
+		[]string{
+			"node", // Node name
+		},
+	)
+
+	// thresholdMode tracks whether we're using static or deviation-based thresholds
+	thresholdMode = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "descheduler_softtainter_threshold_mode",
+			Help: "Threshold mode: 0=static thresholds, 1=deviation-based thresholds",
+		},
+	)
+)
+
+func init() {
+	// Register custom metrics with the controller-runtime metrics registry
+	metrics.Registry.MustRegister(
+		nodeUtilizationThreshold,
+		nodeUtilizationValue,
+		nodeClassification,
+		thresholdMode,
+	)
+}
+
+// resetMetrics clears all node-specific metrics
+func resetMetrics() {
+	nodeUtilizationThreshold.Reset()
+	nodeUtilizationValue.Reset()
+	nodeClassification.Reset()
+}
+
+// recordThresholdMode records whether we're using static or deviation-based thresholds
+func recordThresholdMode(useDeviationThresholds bool) {
+	if useDeviationThresholds {
+		thresholdMode.Set(1)
+	} else {
+		thresholdMode.Set(0)
+	}
+}
+
+// recordNodeMetrics records all metrics for a node
+func recordNodeMetrics(nodeName string, classification int, utilization, lowThreshold, highThreshold api.ResourceThresholds) {
+	// Record classification
+	nodeClassification.WithLabelValues(nodeName).Set(float64(classification))
+
+	// Record utilization values (convert from 0-100 percentage to 0-1 ratio)
+	for resource, value := range utilization {
+		nodeUtilizationValue.WithLabelValues(nodeName, string(resource)).Set(float64(value) / 100.0)
+	}
+
+	// Record low thresholds (convert from 0-100 percentage to 0-1 ratio)
+	for resource, value := range lowThreshold {
+		nodeUtilizationThreshold.WithLabelValues(nodeName, string(resource), "low").Set(float64(value) / 100.0)
+	}
+
+	// Record high thresholds (convert from 0-100 percentage to 0-1 ratio)
+	for resource, value := range highThreshold {
+		nodeUtilizationThreshold.WithLabelValues(nodeName, string(resource), "high").Set(float64(value) / 100.0)
+	}
+}


### PR DESCRIPTION
Add HTTPS metrics support to the softtainter pod using controller-runtime:
- Configure metrics server with TLS on port 8443
- Create Service with automatic certificate provisioning
- Create ServiceMonitor for Prometheus scraping

Expose classification metrics to track node utilization and decisions:
- descheduler_softtainter_node_utilization_threshold: threshold values (0-1)
- descheduler_softtainter_node_utilization_value: actual utilization (0-1)
- descheduler_softtainter_node_classification: classification result (0/1/2)
- descheduler_softtainter_threshold_mode: static vs deviation-based (0/1)

All utilization metrics use 0-1 ratio format for consistency with Prometheus best practices and easy comparison in queries.