### PR TITLE
no-jira: chore(dockerfiles): set distribution-scope=public

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ LABEL io.k8s.display-name="Kube Descheduler Operator based on RHEL 9" \
       io.openshift.expose-services="" \
       io.openshift.tags="openshift,kube-descheduler-operator" \
       description="kube-descheduler-operator-container" \
+      distribution-scope=public \
       maintainer="AOS workloads team, <aos-workloads@redhat.com>"
 
 USER nobody

--- a/Dockerfile.metadata
+++ b/Dockerfile.metadata
@@ -12,4 +12,5 @@ LABEL io.k8s.display-name="OpenShift Kube Descheduler Operator metadata" \
       io.k8s.description="This is a component of OpenShift and manages the kube descheduler metadata" \
       io.openshift.tags="openshift,cluster-kube-descheduler-operator,metadata" \
       com.redhat.delivery.appregistry=true \
+      distribution-scope=public \
       maintainer="AOS workloads team, <aos-workloads@redhat.com>"

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -11,4 +11,5 @@ LABEL io.k8s.display-name="OpenShift Descheduler Operator" \
       io.k8s.description="This is a component of OpenShift and manages the descheduler" \
       io.openshift.tags="openshift,cluster-kube-descheduler-operator" \
       com.redhat.delivery.appregistry=true \
+      distribution-scope=public \
       maintainer="AOS workloads team, <aos-workloads@redhat.com>"

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -54,6 +54,7 @@ LABEL io.openshift.tags="openshift,kube-descheduler-operator"
 LABEL com.redhat.delivery.operator.bundle=true
 LABEL com.redhat.openshift.versions="v4.14"
 LABEL com.redhat.delivery.appregistry=true
+LABEL distribution-scope=public
 LABEL maintainer="AOS workloads team, <aos-workloads-staff@redhat.com>"
 
 USER 1001


### PR DESCRIPTION
```
✕ [Violation] labels.required_labels
    ...
    Reason: The required "distribution-scope" label is missing. Label description: Scope of intended distribution of the image.
    (private/authoritative-source-only/restricted/public).
    Term: distribution-scope
    Title: Required labels
    ...
    Solution: Update the image build process to set the required labels.
```