### PR TITLE
feat(cr validation): enforce spec.deschedulingIntervalSeconds > 0 on the crd validation level

### DIFF
--- a/bindata/assets/kube-descheduler/crdschema.yaml
+++ b/bindata/assets/kube-descheduler/crdschema.yaml
@@ -23,6 +23,7 @@ properties:
       deschedulingIntervalSeconds:
         description: DeschedulingIntervalSeconds is the number of seconds between descheduler runs
         format: int32
+        minimum: 1
         type: integer
       evictionLimits:
         description: evictionLimits restrict the number of evictions during each descheduling run

--- a/manifests/kube-descheduler-operator.crd.yaml
+++ b/manifests/kube-descheduler-operator.crd.yaml
@@ -39,6 +39,7 @@ spec:
                 deschedulingIntervalSeconds:
                   description: DeschedulingIntervalSeconds is the number of seconds between descheduler runs
                   format: int32
+                  minimum: 1
                   type: integer
                 evictionLimits:
                   description: evictionLimits restrict the number of evictions during each descheduling run

--- a/pkg/apis/descheduler/v1/types_descheduler.go
+++ b/pkg/apis/descheduler/v1/types_descheduler.go
@@ -34,6 +34,7 @@ type KubeDeschedulerSpec struct {
 
 	// DeschedulingIntervalSeconds is the number of seconds between descheduler runs
 	// +optional
+	// +kubebuilder:validation:Minimum=1
 	DeschedulingIntervalSeconds *int32 `json:"deschedulingIntervalSeconds,omitempty"`
 
 	// evictionLimits restrict the number of evictions during each descheduling run

--- a/pkg/operator/target_config_reconciler_test.go
+++ b/pkg/operator/target_config_reconciler_test.go
@@ -1927,6 +1927,30 @@ func TestValidateDescheduler(t *testing.T) {
 			}),
 			wantErr: true,
 		},
+		{
+			name: "Descheduler with zero interval - rejected by schema validation",
+			descheduler: buildKubeDeschedulerSpec(func(spec *deschedulerv1.KubeDeschedulerSpec) {
+				spec.DeschedulingIntervalSeconds = utilptr.To[int32](0)
+				spec.Profiles = []deschedulerv1.DeschedulerProfile{deschedulerv1.AffinityAndTaints}
+			}),
+			wantErr: true,
+		},
+		{
+			name: "Descheduler with negative interval - rejected by schema validation",
+			descheduler: buildKubeDeschedulerSpec(func(spec *deschedulerv1.KubeDeschedulerSpec) {
+				spec.DeschedulingIntervalSeconds = utilptr.To[int32](-10)
+				spec.Profiles = []deschedulerv1.DeschedulerProfile{deschedulerv1.AffinityAndTaints}
+			}),
+			wantErr: true,
+		},
+		{
+			name: "Descheduler with positive interval",
+			descheduler: buildKubeDeschedulerSpec(func(spec *deschedulerv1.KubeDeschedulerSpec) {
+				spec.DeschedulingIntervalSeconds = utilptr.To[int32](100)
+				spec.Profiles = []deschedulerv1.DeschedulerProfile{deschedulerv1.AffinityAndTaints}
+			}),
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/test/e2e/bindata/assets/00_kube-descheduler-operator-crd.yaml
+++ b/test/e2e/bindata/assets/00_kube-descheduler-operator-crd.yaml
@@ -39,6 +39,7 @@ spec:
                 deschedulingIntervalSeconds:
                   description: DeschedulingIntervalSeconds is the number of seconds between descheduler runs
                   format: int32
+                  minimum: 1
                   type: integer
                 evictionLimits:
                   description: evictionLimits restrict the number of evictions during each descheduling run


### PR DESCRIPTION
Until now, `deschedulingIntervalSeconds` has been validated by the operator. Any user has been able to create an invalid KubeDescheduler configuration. However, an invalid configuration does not result in a running descheduler operand.

From now on, validation is enforced on the server side through the CRD schema. In the worst-case scenario, a user will no longer be able to create or update a CR that sets `deschedulingIntervalSeconds` to an invalid value—something that previously resulted in an invalid configuration.