### PR TITLE
KubeVirtRelieveAndMigrate: add stable scoring pipeline and eviction cooldown to reduce descheduling churn

### DIFF
--- a/bindata/assets/kube-descheduler/prometheusrule.yaml
+++ b/bindata/assets/kube-descheduler/prometheusrule.yaml
@@ -148,3 +148,29 @@ spec:
               3 * descheduler:node:ideal_point_positive_distance:p66_5m,
               1.0
             )
+
+        # Track successful eviction by LowNodeUtilization strategy count per node in the last 15 minutes
+        - record: descheduler:node:eviction_count:15m
+          expr: |-
+            label_replace(
+              sum by (node) (increase(descheduler_pods_evicted_total{strategy="LowNodeUtilization", result="success"}[15m])),
+              'instance', "$1", 'node', '(.+)'
+            ) or on (instance)
+            descheduler:nodeutilization:cpu:avg1m * 0
+
+        # Calculate the Dampening Factor (Multiplier)
+        # We use a linear decay: each eviction reduces the score by 25%.
+        # 4 evictions in 15m will effectively "mute" the node (multiplier close to 0).
+        - record: descheduler:node:cooldown_multiplier:15m
+          expr: |-
+            clamp_min(
+              1 - (descheduler:node:eviction_count:15m * 0.25),
+              0.01
+            )
+
+        # Actuation Priority: Stable Distance x Cooldown
+        # If the node was recently touched, the distance is suppressed.
+        - record: descheduler:node:actuation_priority:p66_5m
+          expr: |-
+            descheduler:node:linear_amplified_ideal_point_positive_distance:k3:p66_5m
+            * on(instance) descheduler:node:cooldown_multiplier:15m

--- a/bindata/assets/kube-descheduler/prometheusrule.yaml
+++ b/bindata/assets/kube-descheduler/prometheusrule.yaml
@@ -112,3 +112,39 @@ spec:
               3 * descheduler:node:ideal_point_positive_distance:avg1m,
               1.0
             )
+
+        # Stable per-dimension deviations: p66 over 5m
+        # quantile_over_time applied per-dimension BEFORE the Euclidean distance so that
+        # the squaring step does not amplify transient single-dimension spikes.
+        # Asynchronous per-dimension noise (CPU spike in minute 1, memory spike in minute 3)
+        # is filtered independently; applying the quantile only to the final distance would
+        # leave such spikes partially visible after squaring.
+        - record: descheduler:nodeutilization:cpu:p66_5m:positivedeviation
+          expr: quantile_over_time(0.66, descheduler:nodeutilization:cpu:avg1m:positivedeviation[5m])
+
+        - record: descheduler:nodepressure:cpu:p66_5m:positivedeviation
+          expr: quantile_over_time(0.66, descheduler:nodepressure:cpu:avg1m:positivedeviation[5m])
+
+        - record: descheduler:nodeutilization:memory:p66_5m:positivedeviation
+          expr: quantile_over_time(0.66, descheduler:nodeutilization:memory:avg1m:positivedeviation[5m])
+
+        - record: descheduler:nodepressure:memory:p66_5m:positivedeviation
+          expr: quantile_over_time(0.66, descheduler:nodepressure:memory:avg1m:positivedeviation[5m])
+
+        # Stable Euclidean distance using noise-filtered per-dimension deviations
+        - record: descheduler:node:ideal_point_positive_distance:p66_5m
+          expr: |-
+            sqrt(
+              descheduler:nodeutilization:cpu:p66_5m:positivedeviation ^ 2 +
+              descheduler:nodepressure:cpu:p66_5m:positivedeviation ^ 2 +
+              descheduler:nodeutilization:memory:p66_5m:positivedeviation ^ 2 +
+              descheduler:nodepressure:memory:p66_5m:positivedeviation ^ 2
+            )
+
+        # Stable Linear Amplified Ideal Point Positive Distance (k=3.0)
+        - record: descheduler:node:linear_amplified_ideal_point_positive_distance:k3:p66_5m
+          expr: |-
+            clamp_max(
+              3 * descheduler:node:ideal_point_positive_distance:p66_5m,
+              1.0
+            )

--- a/bindata/assets/kube-descheduler/prometheusrule.yaml
+++ b/bindata/assets/kube-descheduler/prometheusrule.yaml
@@ -127,3 +127,39 @@ spec:
               3 * descheduler:node:ideal_point_positive_distance:avg1m,
               1.0
             )
+
+        # Stable per-dimension deviations: p66 over 5m
+        # quantile_over_time applied per-dimension BEFORE the Euclidean distance so that
+        # the squaring step does not amplify transient single-dimension spikes.
+        # Asynchronous per-dimension noise (CPU spike in minute 1, memory spike in minute 3)
+        # is filtered independently; applying the quantile only to the final distance would
+        # leave such spikes partially visible after squaring.
+        - record: descheduler:nodeutilization:cpu:p66_5m:positivedeviation
+          expr: quantile_over_time(0.66, descheduler:nodeutilization:cpu:avg1m:positivedeviation[5m])
+
+        - record: descheduler:nodepressure:cpu:p66_5m:positivedeviation
+          expr: quantile_over_time(0.66, descheduler:nodepressure:cpu:avg1m:positivedeviation[5m])
+
+        - record: descheduler:nodeutilization:memory:p66_5m:positivedeviation
+          expr: quantile_over_time(0.66, descheduler:nodeutilization:memory:avg1m:positivedeviation[5m])
+
+        - record: descheduler:nodepressure:memory:p66_5m:positivedeviation
+          expr: quantile_over_time(0.66, descheduler:nodepressure:memory:avg1m:positivedeviation[5m])
+
+        # Stable Euclidean distance using noise-filtered per-dimension deviations
+        - record: descheduler:node:ideal_point_positive_distance:p66_5m
+          expr: |-
+            sqrt(
+              descheduler:nodeutilization:cpu:p66_5m:positivedeviation ^ 2 +
+              descheduler:nodepressure:cpu:p66_5m:positivedeviation ^ 2 +
+              descheduler:nodeutilization:memory:p66_5m:positivedeviation ^ 2 +
+              descheduler:nodepressure:memory:p66_5m:positivedeviation ^ 2
+            )
+
+        # Stable Linear Amplified Ideal Point Positive Distance (k=3.0)
+        - record: descheduler:node:linear_amplified_ideal_point_positive_distance:k3:p66_5m
+          expr: |-
+            clamp_max(
+              3 * descheduler:node:ideal_point_positive_distance:p66_5m,
+              1.0
+            )

--- a/bindata/assets/kube-descheduler/prometheusrule.yaml
+++ b/bindata/assets/kube-descheduler/prometheusrule.yaml
@@ -163,3 +163,29 @@ spec:
               3 * descheduler:node:ideal_point_positive_distance:p66_5m,
               1.0
             )
+
+        # Track successful eviction by LowNodeUtilization strategy count per node in the last 10 minutes
+        - record: descheduler:node:eviction_count:10m
+          expr: |-
+            label_replace(
+              sum by (node) (increase(descheduler_pods_evicted_total{strategy="LowNodeUtilization", result="success"}[10m])),
+              'instance', "$1", 'node', '(.+)'
+            ) or on (instance)
+            descheduler:nodeutilization:cpu:avg1m * 0
+
+        # Calculate the Dampening Factor (Multiplier)
+        # We use a linear decay: each eviction reduces the score by 10%.
+        # 10 evictions in 10m will effectively "mute" the node (multiplier close to 0).
+        - record: descheduler:node:cooldown_multiplier:10m
+          expr: |-
+            clamp_min(
+              1 - (descheduler:node:eviction_count:10m * 0.10),
+              0.01
+            )
+
+        # Actuation Priority: Stable Distance x Cooldown
+        # If the node was recently touched, the distance is suppressed.
+        - record: descheduler:node:actuation_priority:p66_5m
+          expr: |-
+            descheduler:node:linear_amplified_ideal_point_positive_distance:k3:p66_5m
+            * on(instance) descheduler:node:cooldown_multiplier:10m


### PR DESCRIPTION
This PR introduces two improvements to the Prometheus-based node scoring used by the descheduler, aimed at reducing instability and spurious eviction loops.

### Stable per-dimension noise filtering (p66/5m) 
Rather than computing the actuation priority from instantaneous 1-minute averages, each positive-deviation dimension (CPU utilization, CPU pressure, memory utilization, memory pressure) is now filtered independently through `quantile_over_time(0.66, ...[5m])` before being combined into the Euclidean distance. Applying the quantile per-dimension, rather than to the final score, is important because the Euclidean distance squares each input: filtering after squaring leaves transient spikes partially visible in the combined result. Per-dimension noise is also often asynchronous (a CPU spike in one interval, a memory spike in another); filtering independently prevents each spike from contributing to the distance at all. The existing :avg1m chain is preserved for comparison and debugging.                                                                                                                 
                  
### Eviction cooldown multiplier
A cooldown mechanism suppresses the actuation priority of nodes that have been recently evicted from, to prevent the descheduler from repeatedly targeting the same node before the effects of prior evictions have settled. The suppression is proportional to the number of successful `LowNodeUtilization` evictions in the past 15 minutes (linear decay, 25% per eviction), and decays naturally as old evictions leave the sliding window.
Known limitation: the cooldown is applied to the eviction source node. Ideally it would also dampen the score of the receiving node, but the descheduler is only involved in the eviction act itself while pod placement is entirely up to the scheduler, which the descheduler has no visibility into.
Requires: https://github.com/kubernetes-sigs/descheduler/pull/1856