### PR TITLE
CNTRLPLANE-2721: fix: add missing persistentvolumeclaims cluster rbac for operand

### DIFF
--- a/bindata/assets/kube-descheduler/operandclusterrole.yaml
+++ b/bindata/assets/kube-descheduler/operandclusterrole.yaml
@@ -21,6 +21,7 @@ rules:
   - "pods"
   - "nodes"
   - "namespaces"
+  - "persistentvolumeclaims"
   verbs:
   - "get"
   - "watch"

--- a/deploy/02_clusterrole.yaml
+++ b/deploy/02_clusterrole.yaml
@@ -71,6 +71,7 @@ rules:
     resources:
       - namespaces
       - pods
+      - persistentvolumeclaims
     verbs:
       - get
       - watch

--- a/manifests/cluster-kube-descheduler-operator.clusterserviceversion.yaml
+++ b/manifests/cluster-kube-descheduler-operator.clusterserviceversion.yaml
@@ -219,6 +219,7 @@ spec:
               resources:
                 - namespaces
                 - pods
+                - persistentvolumeclaims
               verbs:
                 - get
                 - watch

--- a/test/e2e/bindata/assets/03_clusterrole.yaml
+++ b/test/e2e/bindata/assets/03_clusterrole.yaml
@@ -71,6 +71,7 @@ rules:
     resources:
       - namespaces
       - pods
+      - persistentvolumeclaims
     verbs:
       - get
       - watch


### PR DESCRIPTION
```
E0504 22:53:14.379131       1 reflector.go:204] "Failed to watch" err="failed to list *v1.PersistentVolumeClaim: persistentvolumeclaims is forbidden: User \"system:serviceaccount:openshift-kube-descheduler-operator:openshift-descheduler-operand\" cannot list resource \"persistentvolumeclaims\" in API group \"\" at the cluster scope" logger="UnhandledError" reflector="k8s.io/client-go/informers/factory.go:161" type="*v1.PersistentVolumeClaim"
```