### PR TITLE
no-jira: chore: bump bundle.Dockerfile to point to the latest operand image

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -15,7 +15,7 @@ ARG SOFTTAINER_IMAGE=registry.redhat.io/kube-descheduler-operator/kube-deschedul
 #
 #
 #
-ARG OPERAND_IMAGE=registry.redhat.io/kube-descheduler-operator/descheduler-rhel9@sha256:c4cddbcf3bef49f2a4f84ce3b1cc3d14344ec65729cf2475d0f260dcab451e74
+ARG OPERAND_IMAGE=registry.redhat.io/kube-descheduler-operator/descheduler-rhel9@sha256:f8d014f45a8fa119cc85544585f5cb081b427b7d438019a2b38c01e011fc9741
 ARG REPLACED_OPERATOR_IMG=registry-proxy.engineering.redhat.com/rh-osbs/kube-descheduler-operator-rhel-9:latest
 ARG REPLACED_OPERAND_IMG=registry-proxy.engineering.redhat.com/rh-osbs/descheduler-rhel-9:latest
 ARG REPLACED_SOFTTAINER_IMG=registry-proxy.engineering.redhat.com/rh-osbs/kube-descheduler-operator-rhel-9:latest


### PR DESCRIPTION
ssia