### PR TITLE
fix: drop the accidently added architectures, only x86_64 is supported in 4.12/4.13

### DIFF
--- a/.tekton/kube-descheduler-operator-fbc-4-12-pull-request.yaml
+++ b/.tekton/kube-descheduler-operator-fbc-4-12-pull-request.yaml
@@ -31,9 +31,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: catalog.Dockerfile
   - name: path-context

--- a/.tekton/kube-descheduler-operator-fbc-4-12-push.yaml
+++ b/.tekton/kube-descheduler-operator-fbc-4-12-push.yaml
@@ -28,9 +28,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: catalog.Dockerfile
   - name: path-context

--- a/.tekton/kube-descheduler-operator-fbc-4-13-pull-request.yaml
+++ b/.tekton/kube-descheduler-operator-fbc-4-13-pull-request.yaml
@@ -31,9 +31,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: catalog.Dockerfile
   - name: path-context

--- a/.tekton/kube-descheduler-operator-fbc-4-13-push.yaml
+++ b/.tekton/kube-descheduler-operator-fbc-4-13-push.yaml
@@ -28,9 +28,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: catalog.Dockerfile
   - name: path-context


### PR DESCRIPTION
To address the failing https://github.com/openshift/cluster-kube-descheduler-operator/pull/1851