### PR TITLE
CNV-87304: feat: propagate EvictionLimits.Node to LowNodeUtilization plugin args

### DIFF
--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -1117,6 +1117,9 @@ func kubeVirtRelieveAndMigrateProfile(profileCustomizations *deschedulerv1.Profi
 	// profile defaults
 	const defaultActualUtilizationProfile = deschedulerv1.PrometheusCPUMemoryCombinedProfile
 	args.UseDeviationThresholds = true
+	args.EvictionLimits = &deschedulerapi.EvictionLimits{
+		Node: utilptr.To[uint](uint(defaultKVParallelOutboundMigrationsPerNode)),
+	}
 	query, err := utilizationProfileToPrometheusQuery(defaultActualUtilizationProfile)
 	if err != nil {
 		return nil, err
@@ -1321,8 +1324,6 @@ func (c *TargetConfigReconciler) manageConfigMap(descheduler *deschedulerv1.Kube
 		Profiles: []v1alpha2.DeschedulerProfile{},
 	}
 
-	c.setEvictionsLimits(descheduler, policy)
-
 	if c.isPrometheusAsMetricsProviderForProfiles(descheduler) {
 		// detect the prometheus server url
 		route, err := c.routeRouteLister.Routes("openshift-monitoring").Get("prometheus-k8s")
@@ -1408,6 +1409,8 @@ func (c *TargetConfigReconciler) manageConfigMap(descheduler *deschedulerv1.Kube
 		}
 		policy.Profiles = append(policy.Profiles, *profile)
 	}
+
+	c.setEvictionsLimits(descheduler, policy)
 
 	// Check for conflicting kube-scheduler config
 	if scheduler.Spec.Profile == configv1.HighNodeUtilization &&
@@ -1818,6 +1821,17 @@ func (c *TargetConfigReconciler) setEvictionsLimits(descheduler *deschedulerv1.K
 		}
 		if descheduler.Spec.EvictionLimits.Node != nil {
 			policy.MaxNoOfPodsToEvictPerNode = utilptr.To[uint](uint(*descheduler.Spec.EvictionLimits.Node))
+			for i := range policy.Profiles {
+				for j := range policy.Profiles[i].PluginConfigs {
+					if policy.Profiles[i].PluginConfigs[j].Name == nodeutilization.LowNodeUtilizationPluginName {
+						args := policy.Profiles[i].PluginConfigs[j].Args.Object.(*nodeutilization.LowNodeUtilizationArgs)
+						if args.EvictionLimits == nil {
+							args.EvictionLimits = &deschedulerapi.EvictionLimits{}
+						}
+						args.EvictionLimits.Node = utilptr.To[uint](uint(*descheduler.Spec.EvictionLimits.Node))
+					}
+				}
+			}
 		}
 	}
 }

--- a/pkg/operator/testdata/assets/lowNodeUtilizationEvictionLimits.yaml
+++ b/pkg/operator/testdata/assets/lowNodeUtilizationEvictionLimits.yaml
@@ -34,6 +34,8 @@ profiles:
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
+      evictionLimits:
+        node: 3
       targetThresholds:
         cpu: 50
         memory: 50

--- a/pkg/operator/testdata/assets/relieveAndMigrateDefaults.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateDefaults.yaml
@@ -18,6 +18,8 @@ profiles:
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
+      evictionLimits:
+        node: 2
       metricsUtilization:
         prometheus:
           query: descheduler:node:linear_amplified_ideal_point_positive_distance:k3:avg1m

--- a/pkg/operator/testdata/assets/relieveAndMigrateDeviationLowWithCombinedMetrics.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateDeviationLowWithCombinedMetrics.yaml
@@ -18,6 +18,8 @@ profiles:
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
+      evictionLimits:
+        node: 2
       metricsUtilization:
         prometheus:
           query: descheduler:combined_utilization_and_pressure:avg1m

--- a/pkg/operator/testdata/assets/relieveAndMigrateDynamicThresholdsHigh.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateDynamicThresholdsHigh.yaml
@@ -18,6 +18,8 @@ profiles:
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
+      evictionLimits:
+        node: 2
       metricsUtilization:
         prometheus:
           query: descheduler:node:linear_amplified_ideal_point_positive_distance:k3:avg1m

--- a/pkg/operator/testdata/assets/relieveAndMigrateDynamicThresholdsLow.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateDynamicThresholdsLow.yaml
@@ -18,6 +18,8 @@ profiles:
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
+      evictionLimits:
+        node: 2
       metricsUtilization:
         prometheus:
           query: descheduler:node:linear_amplified_ideal_point_positive_distance:k3:avg1m

--- a/pkg/operator/testdata/assets/relieveAndMigrateDynamicThresholdsMedium.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateDynamicThresholdsMedium.yaml
@@ -18,6 +18,8 @@ profiles:
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
+      evictionLimits:
+        node: 2
       metricsUtilization:
         prometheus:
           query: descheduler:node:linear_amplified_ideal_point_positive_distance:k3:avg1m

--- a/pkg/operator/testdata/assets/relieveAndMigrateEvictionLimits.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateEvictionLimits.yaml
@@ -18,6 +18,8 @@ profiles:
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
+      evictionLimits:
+        node: 3
       metricsUtilization:
         prometheus:
           query: descheduler:node:linear_amplified_ideal_point_positive_distance:k3:avg1m

--- a/pkg/operator/testdata/assets/relieveAndMigrateHighConfig.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateHighConfig.yaml
@@ -18,6 +18,8 @@ profiles:
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
+      evictionLimits:
+        node: 2
       metricsUtilization:
         prometheus:
           query: descheduler:node:linear_amplified_ideal_point_positive_distance:k3:avg1m

--- a/pkg/operator/testdata/assets/relieveAndMigrateIncludedNamespace.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateIncludedNamespace.yaml
@@ -18,6 +18,8 @@ profiles:
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
+      evictionLimits:
+        node: 2
       metricsUtilization:
         prometheus:
           query: descheduler:node:linear_amplified_ideal_point_positive_distance:k3:avg1m

--- a/pkg/operator/testdata/assets/relieveAndMigrateLowConfig.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateLowConfig.yaml
@@ -18,6 +18,8 @@ profiles:
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
+      evictionLimits:
+        node: 2
       metricsUtilization:
         prometheus:
           query: descheduler:node:linear_amplified_ideal_point_positive_distance:k3:avg1m

--- a/pkg/operator/testdata/assets/relieveAndMigrateMediumConfig.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateMediumConfig.yaml
@@ -18,6 +18,8 @@ profiles:
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
+      evictionLimits:
+        node: 2
       metricsUtilization:
         prometheus:
           query: descheduler:node:linear_amplified_ideal_point_positive_distance:k3:avg1m


### PR DESCRIPTION
Set a default per-plugin eviction node limit of 2 on the `LowNodeUtilization` plugin for the `KubeVirtRelieveAndMigrate` profile, matching the existing global `MaxNoOfPodsToEvictPerNode` default.

When `LowNodeUtilization` is configured with a Prometheus metric as the utilization source, resource usage data is available per node but not per pod. In that case the plugin sets `unconstrainedResourceEviction=true` and, without an explicit per-plugin `EvictionLimits.Node`, self-limits to a single eviction per node per cycle regardless of the global `MaxNoOfPodsToEvictPerNode` budget (see `nodeutilization.go evictPods`). Explicitly setting `EvictionLimits.Node` overrides that fallback and allows up to `defaultKVParallelOutboundMigrationsPerNode` (2) VM live migrations per node per cycle, which is what KubeVirt can handle by default.

Refactor `setEvictionsLimits` to run after profiles are built so it can iterate over all profiles and propagate `descheduler.Spec.EvictionLimits.Node` into the `EvictionLimits.Node` of any `LowNodeUtilization` plugin config, overriding the default when the user explicitly sets it on the CR.

Fixes: https://redhat.atlassian.net/browse/CNV-87304