### PR TITLE
feat(.tekton): add DAST integration test pipeline for KDO 4.21

### DIFF
--- a/.tekton/integration-tests/README.md
+++ b/.tekton/integration-tests/README.md
@@ -1,0 +1,139 @@
+# KDO DAST Integration Tests on Konflux
+
+## Overview
+
+This directory contains the DAST (Dynamic Application Security Testing) pipeline for the
+Kube Descheduler Operator (KDO) on Konflux. The pipeline runs automatically when the KDO
+bundle image is built, provisioning an ephemeral OCP cluster and executing security scans.
+
+## Pipeline
+
+**File:** `pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml`
+
+### What it does
+
+1. **Provisions** an ephemeral OCP 4.21 cluster via EaaS (Environment as a Service)
+2. **Installs** the KDO operator from the Konflux-built SNAPSHOT bundle using `operator-sdk run bundle`
+3. **Applies** an enriched `KubeDescheduler` CR with all spec fields populated to maximize test coverage
+4. **Runs oobtkube** (out-of-box testing for Kubernetes) as a Job on the ephemeral cluster to detect
+   blind command injection vulnerabilities in the operator's CR reconciliation logic
+5. **Runs Trivy** misconfiguration scan against deployed KDO workloads
+6. **Uploads results** to GCS (`secaut-bucket`) and surfaces findings in the Konflux UI
+   via `TEST_OUTPUT` / `SCAN_OUTPUT` task results
+
+### Architecture
+
+```
+Konflux Build Pipeline
+        |
+        v  (SNAPSHOT with bundle image)
+IntegrationTestScenario (konflux-release-data)
+        |
+        v  (git resolver)
+DAST Pipeline (this repo)
+        |
+        +-- parse-metadata
+        +-- eaas-provision-space (ownerKind: PipelineRun)
+        +-- provision-cluster (OCP 4.21 + imageContentSources)
+        +-- install-kdo-operator (operator-sdk run bundle from SNAPSHOT)
+        +-- dast-test
+              +-- get-kubeconfig
+              +-- orchestrate-dast (kubectl: ns, RBAC, ConfigMap, RapiDAST Job)
+              +-- run-trivy (trivy k8s --kubeconfig)
+              +-- post-process (TEST_OUTPUT + SCAN_OUTPUT)
+```
+
+oobtkube runs **on the ephemeral cluster** as a Kubernetes Job (not as a Tekton step).
+This ensures the oobtkube TCP listener and the KDO operator share the same network,
+allowing the callback mechanism to work correctly.
+
+### Container images used
+
+| Step | Image | Why |
+|------|-------|-----|
+| install-operator, orchestrate-dast, post-process | `quay.io/konflux-ci/konflux-test:latest` | Has `oc`, `kubectl`, `jq`, `/utils.sh` |
+| RapiDAST Job (on ephemeral cluster) | `quay.io/redhatproductsecurity/rapidast:latest` | Has `rapidast.py`, `oobtkube.py` (via `python3.12`), `trivy`, `kubectl` |
+| run-trivy | `quay.io/redhatproductsecurity/rapidast:latest` | Has `trivy` |
+| results-fetcher | `registry.access.redhat.com/ubi9/ubi:latest` | Pod to mount PVC for `kubectl cp` (needs `tar`) |
+
+## Prerequisites
+
+### GCS Secret
+
+A Google Cloud Storage service account key must be provisioned in the `kdo-workloads-tenant`
+namespace on the Konflux cluster:
+
+- **Secret name:** `rapidast-sa-kdo-key`
+- **Key:** `sa-key` (JSON service account credentials)
+- **Bucket:** `secaut-bucket`
+
+Request access via the SecAut Bucket Access Repository (same process as RHOSDT).
+
+### IntegrationTestScenario
+
+The ITS resource `kube-descheduler-operator-4-21-dast` must exist in
+`konflux-release-data` under the `kdo-workloads-tenant`. It is configured with:
+
+- `test.appstudio.openshift.io/optional: "true"` label (non-blocking)
+- Context filter: `component_kube-descheduler-operator-bundle-4-21` (triggers on bundle builds)
+- Param: `kdo_version: "4.21"` (for GCS path tagging)
+
+### imageContentSources
+
+The ephemeral cluster is configured with image content source mirrors so that
+`operator-sdk run bundle` can pull images built by Konflux:
+
+| Registry source | Konflux mirror |
+|----------------|----------------|
+| `registry.redhat.io/kube-descheduler-operator/kube-descheduler-rhel9-operator` | `quay.io/redhat-user-workloads/kdo-workloads-tenant/kube-descheduler-operator` |
+| `registry.redhat.io/kube-descheduler-operator/descheduler-rhel9` | `quay.io/redhat-user-workloads/kdo-workloads-tenant/kube-descheduler-operator` |
+| `registry.redhat.io/kube-descheduler-operator/kube-descheduler-operator-bundle` | `quay.io/redhat-user-workloads/kdo-workloads-tenant/kube-descheduler-operator-bundle` |
+
+## Interpreting Results
+
+### Konflux UI
+
+- **TEST_OUTPUT**: Shows `SUCCESS` if the pipeline completed. Check `SCAN_OUTPUT` for details.
+- **SCAN_OUTPUT**: JSON with vulnerability counts by severity (critical/high/medium/low).
+
+### GCS Archive
+
+Results are uploaded to `gs://secaut-bucket/kdo/<version>/oobtkube/` by RapiDAST's
+native `google.cloud.storage` integration. Contains the full SARIF report.
+
+### oobtkube Findings
+
+oobtkube detects blind command injection by injecting `curl <pod-ip>:<port>` payloads
+into CR string fields. The pod IP is injected via the Kubernetes downward API (`POD_IP` env var).
+If the operator executes any injected command, oobtkube's listener receives the callback
+and reports a finding. Any finding indicates a critical vulnerability.
+
+The scanner is configured as `generic_oobtkube` in RapiDAST (using the `generic_<name>` pattern)
+and uses `python3.12` (the default `python3` in the RapiDAST image lacks `pyyaml`).
+
+### Trivy Findings
+
+Trivy scans deployed KDO workloads for Kubernetes misconfigurations (HIGH/CRITICAL severity).
+Results are saved as JSON in the shared volume.
+
+## Enriched CR
+
+The test uses an enriched `KubeDescheduler` CR with maximum field coverage:
+
+- **5 compatible profiles**: AffinityAndTaints, SoftTopologyAndDuplicates, LifecycleAndUtilization,
+  EvictPodsWithLocalStorage, EvictPodsWithPVC
+- **All profileCustomizations** including free-string fields (`devActualUtilizationProfile`,
+  `thresholdPriorityClassName`) that are primary oobtkube injection targets
+- **All numeric/boolean fields** populated to exercise full operator reconciliation paths
+
+## Known Limitations
+
+- **Trivy namespace flag**: Trivy k8s uses `--include-namespaces` (not `--namespace`).
+- **`python3.12` required for oobtkube**: The RapiDAST image's default `python3` (3.9) lacks
+  `pyyaml`. The config must use `python3.12` for the oobtkube inline command.
+- **`hostname` unavailable in RapiDAST container**: Pod IP must be injected via the Kubernetes
+  downward API (`POD_IP` env var) instead of `$(hostname -i)`.
+- **`operator-sdk` runtime download**: Currently downloaded at runtime. Consider building
+  a lightweight KDO test image if more integration tests are added.
+- **Non-hermetic**: Integration test pipelines on Konflux are not subject to hermetic build
+  constraints. Runtime downloads and `:latest` tags are acceptable per Konflux docs.

--- a/.tekton/integration-tests/configs/kdo-cr.yaml
+++ b/.tekton/integration-tests/configs/kdo-cr.yaml
@@ -1,0 +1,35 @@
+apiVersion: operator.openshift.io/v1
+kind: KubeDescheduler
+metadata:
+  name: cluster
+  namespace: openshift-kube-descheduler-operator
+spec:
+  managementState: Managed
+  deschedulingIntervalSeconds: 30
+  mode: "Automatic"
+  logLevel: "Debug"
+  operatorLogLevel: "Debug"
+  evictionLimits:
+    node: 10
+    total: 100
+  profiles:
+    - AffinityAndTaints
+    - SoftTopologyAndDuplicates
+    - LifecycleAndUtilization
+    - EvictPodsWithLocalStorage
+    - EvictPodsWithPVC
+  profileCustomizations:
+    podLifetime: "48h"
+    devActualUtilizationProfile: "production-metrics"
+    devDeviationThresholds: "Medium"
+    devEnableEvictionsInBackground: true
+    devHighNodeUtilizationThresholds: "Moderate"
+    devLowNodeUtilizationThresholds: "Medium"
+    thresholdPriorityClassName: "system-cluster-critical"
+    namespaces:
+      included:
+        - "default"
+        - "test-descheduling"
+      excluded:
+        - "kube-system"
+        - "openshift-monitoring"

--- a/.tekton/integration-tests/configs/rapidast-job.yaml
+++ b/.tekton/integration-tests/configs/rapidast-job.yaml
@@ -1,0 +1,54 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rapidast-kdo-oobtkube
+  namespace: rapidast-kdo
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      serviceAccountName: privileged-sa
+      containers:
+        - name: rapidast
+          image: quay.io/redhatproductsecurity/rapidast:latest
+          imagePullPolicy: Always
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              rapidast.py --log-level debug --config /opt/rapidast/config/rapidastconfig.yaml
+              RESULT=$?
+              cp /opt/rapidast/results/*.sarif /opt/rapidast/pvc-results/ 2>/dev/null || true
+              exit $RESULT
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 2000m
+              memory: 4Gi
+          volumeMounts:
+            - name: config
+              mountPath: /opt/rapidast/config
+            - name: results
+              mountPath: /opt/rapidast/pvc-results
+            - name: gcs-key
+              mountPath: /etc/gcs
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: rapidast-kdo-config
+        - name: results
+          persistentVolumeClaim:
+            claimName: rapidast-pvc
+        - name: gcs-key
+          secret:
+            secretName: rapidast-sa-kdo-key
+      restartPolicy: Never

--- a/.tekton/integration-tests/configs/rapidast-job.yaml
+++ b/.tekton/integration-tests/configs/rapidast-job.yaml
@@ -18,6 +18,7 @@ spec:
               rapidast.py --log-level debug --config /opt/rapidast/config/rapidastconfig.yaml
               RESULT=$?
               cp /opt/rapidast/results/*.sarif /opt/rapidast/pvc-results/ 2>/dev/null || true
+              cp /opt/rapidast/results/*.json /opt/rapidast/pvc-results/ 2>/dev/null || true
               exit $RESULT
           env:
             - name: POD_IP

--- a/.tekton/integration-tests/configs/rapidastconfig.yaml
+++ b/.tekton/integration-tests/configs/rapidastconfig.yaml
@@ -3,11 +3,8 @@ config:
   googleCloudStorage:
     keyFile: "/etc/gcs/sa-key"
     bucketName: "secaut-bucket"
-    # Current: latest scan overwrites previous for the same version (same as OTEL).
-    # To keep per-run history in GCS, append a unique suffix, e.g.:
-    #   directory: "kdo/${KDO_VERSION}/oobtkube/${PIPELINE_RUN_ID}"
-    # Note: Konflux UI already preserves SCAN_OUTPUT per PipelineRun regardless.
-    directory: "kdo/${KDO_VERSION}/oobtkube"
+    # Each scanner's results land under kdo/<version>/<scanner-name>/
+    directory: "kdo/${KDO_VERSION}"
 
 application:
   shortName: "kdo"
@@ -22,3 +19,8 @@ scanners:
     results: "/opt/rapidast/results/oobtkube-results.sarif"
     inline: |
       python3.12 oobtkube.py --find-all --log-level debug -d 300 -p 6000 -i ${POD_IP} -f /opt/rapidast/config/kdo-cr.yaml -o /opt/rapidast/results/oobtkube-results.sarif
+
+  generic_trivy:
+    results: "/opt/rapidast/results/trivy-results.json"
+    inline: |
+      trivy k8s --include-namespaces openshift-kube-descheduler-operator --scanners=misconfig --severity HIGH,CRITICAL --report all --format json --output /opt/rapidast/results/trivy-results.json --skip-check-update

--- a/.tekton/integration-tests/configs/rapidastconfig.yaml
+++ b/.tekton/integration-tests/configs/rapidastconfig.yaml
@@ -1,0 +1,24 @@
+config:
+  configVersion: 6
+  googleCloudStorage:
+    keyFile: "/etc/gcs/sa-key"
+    bucketName: "secaut-bucket"
+    # Current: latest scan overwrites previous for the same version (same as OTEL).
+    # To keep per-run history in GCS, append a unique suffix, e.g.:
+    #   directory: "kdo/${KDO_VERSION}/oobtkube/${PIPELINE_RUN_ID}"
+    # Note: Konflux UI already preserves SCAN_OUTPUT per PipelineRun regardless.
+    directory: "kdo/${KDO_VERSION}/oobtkube"
+
+application:
+  shortName: "kdo"
+  url: "https://kubernetes.default.svc"
+
+general:
+  container:
+    type: "none"
+
+scanners:
+  generic_oobtkube:
+    results: "/opt/rapidast/results/oobtkube-results.sarif"
+    inline: |
+      python3.12 oobtkube.py --find-all --log-level debug -d 300 -p 6000 -i ${POD_IP} -f /opt/rapidast/config/kdo-cr.yaml -o /opt/rapidast/results/oobtkube-results.sarif

--- a/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
+++ b/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
@@ -303,16 +303,16 @@ spec:
               trap 'echo "DAST orchestration failed"; exit 1' ERR
 
               # --- 1. Create namespace and RBAC on ephemeral cluster ---
-              kubectl create namespace rapidast-kdo
-              kubectl create sa privileged-sa -n rapidast-kdo
-              kubectl create clusterrolebinding rapidast-privileged \
+              oc create namespace rapidast-kdo
+              oc create sa privileged-sa -n rapidast-kdo
+              oc create clusterrolebinding rapidast-privileged \
                 --clusterrole=cluster-admin --serviceaccount=rapidast-kdo:privileged-sa
 
               # --- 2. Propagate GCS secret to ephemeral cluster ---
-              kubectl create secret generic rapidast-sa-kdo-key \
+              oc create secret generic rapidast-sa-kdo-key \
                 --from-file=sa-key=/etc/gcs/sa-key \
                 --namespace=rapidast-kdo \
-                --dry-run=client -o yaml | kubectl apply -f -
+                --dry-run=client -o yaml | oc apply -f -
 
               # --- 3. Fetch config files from repo ---
               REPO_RAW="https://raw.githubusercontent.com/openshift/cluster-kube-descheduler-operator/${CONFIG_GIT_REVISION}"
@@ -325,7 +325,7 @@ spec:
               envsubst '${KDO_VERSION}' < /tmp/rapidastconfig.yaml > /tmp/rapidastconfig-resolved.yaml
 
               # --- 4. Create PVC for results on ephemeral cluster ---
-              cat <<'PVCEOF' | kubectl apply -f -
+              cat <<'PVCEOF' | oc apply -f -
               apiVersion: v1
               kind: PersistentVolumeClaim
               metadata:
@@ -340,37 +340,37 @@ spec:
               PVCEOF
 
               # --- 5. Create RapiDAST ConfigMap from fetched config files ---
-              kubectl create configmap rapidast-kdo-config \
+              oc create configmap rapidast-kdo-config \
                 --from-file=rapidastconfig.yaml=/tmp/rapidastconfig-resolved.yaml \
                 --from-file=kdo-cr.yaml=/tmp/kdo-cr.yaml \
                 --namespace=rapidast-kdo
 
               # --- 6. Apply enriched CR on ephemeral cluster (for operator to reconcile) ---
-              kubectl apply -f /tmp/kdo-cr.yaml
+              oc apply -f /tmp/kdo-cr.yaml
 
               # Wait for operator to reconcile the CR
               sleep 15
-              kubectl wait --for condition=Available \
+              oc wait --for condition=Available \
                 -n openshift-kube-descheduler-operator \
                 deployment/descheduler-operator \
                 --timeout=120s
 
               # --- 7. Create RapiDAST Job on ephemeral cluster ---
               curl -sfL "${REPO_RAW}/${CONFIG_DIR}/rapidast-job.yaml" > /tmp/rapidast-job.yaml
-              kubectl apply -f /tmp/rapidast-job.yaml
+              oc apply -f /tmp/rapidast-job.yaml
 
               # --- 8. Wait for Job to terminate (complete or fail) ---
-              kubectl wait --for=condition=complete job/rapidast-kdo-oobtkube \
+              oc wait --for=condition=complete job/rapidast-kdo-oobtkube \
                 -n rapidast-kdo --timeout=600s 2>/dev/null \
-                || kubectl wait --for=condition=failed job/rapidast-kdo-oobtkube \
+                || oc wait --for=condition=failed job/rapidast-kdo-oobtkube \
                 -n rapidast-kdo --timeout=30s 2>/dev/null \
                 || echo "Job still running after timeout"
 
               # --- 9. Capture Job logs ---
-              kubectl logs job/rapidast-kdo-oobtkube -n rapidast-kdo > /shared/rapidast-kdo-log.txt 2>&1 || true
+              oc logs job/rapidast-kdo-oobtkube -n rapidast-kdo > /shared/rapidast-kdo-log.txt 2>&1 || true
 
               # --- 10. Retrieve SARIF from PVC via helper pod ---
-              cat <<'CPEOF' | kubectl apply -f -
+              cat <<'CPEOF' | oc apply -f -
               apiVersion: v1
               kind: Pod
               metadata:
@@ -390,8 +390,8 @@ spec:
                       claimName: rapidast-pvc
                 restartPolicy: Never
               CPEOF
-              kubectl wait --for=condition=Ready pod/results-fetcher -n rapidast-kdo --timeout=60s
-              kubectl cp rapidast-kdo/results-fetcher:/results/oobtkube-results.sarif /shared/oobtkube-results.sarif || true
+              oc wait --for=condition=Ready pod/results-fetcher -n rapidast-kdo --timeout=60s
+              oc cp rapidast-kdo/results-fetcher:/results/oobtkube-results.sarif /shared/oobtkube-results.sarif || true
 
               echo "DAST orchestration complete. Results in /shared/"
 

--- a/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
+++ b/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
@@ -251,6 +251,12 @@ spec:
             description: Tekton task test output.
           - name: SCAN_OUTPUT
             description: DAST scan result.
+          - name: OOBTKUBE_SARIF
+            description: Raw oobtkube SARIF results (truncated to 4KB if needed).
+          - name: TRIVY_JSON
+            description: Raw Trivy misconfiguration JSON results (truncated to 4KB if needed).
+          - name: RAPIDAST_LOG
+            description: RapiDAST Job logs (truncated to 4KB if needed).
         volumes:
           - name: credentials
             emptyDir: {}
@@ -443,6 +449,25 @@ spec:
               fi
 
               echo "$scan_result" | tee "$(results.SCAN_OUTPUT.path)"
+
+              # --- Write raw scan artifacts (truncated to 4KB for Tekton limit) ---
+              truncate_to_result() {
+                local file="$1" dest="$2" limit=4096
+                if [ -s "$file" ]; then
+                  if [ "$(wc -c < "$file")" -gt "$limit" ]; then
+                    head -c $limit "$file" > "$dest"
+                    echo -e "\n... [TRUNCATED - full results in GCS]" >> "$dest"
+                  else
+                    cp "$file" "$dest"
+                  fi
+                else
+                  echo "No results collected" > "$dest"
+                fi
+              }
+
+              truncate_to_result /shared/oobtkube-results.sarif "$(results.OOBTKUBE_SARIF.path)"
+              truncate_to_result /shared/trivy-results.json "$(results.TRIVY_JSON.path)"
+              truncate_to_result /shared/rapidast-kdo-log.txt "$(results.RAPIDAST_LOG.path)"
 
               note="Task $(context.task.name) completed: Refer to SCAN_OUTPUT for DAST findings."
               TEST_OUTPUT=$(make_result_json -r "SUCCESS" -t "$note")

--- a/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
+++ b/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
@@ -126,7 +126,7 @@ spec:
               - name: instanceType
                 value: "m5.xlarge"
               - name: timeout
-                value: "30m"
+                value: "40m"
               - name: imageContentSources
                 value: |
                   - source: registry.redhat.io/kube-descheduler-operator/kube-descheduler-rhel9-operator

--- a/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
+++ b/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
@@ -18,6 +18,10 @@ spec:
     - name: kdo_version
       description: "KDO product version used to tag RapiDAST scan results in GCS"
       type: string
+    - name: config_git_revision
+      description: "Git branch/revision used to fetch config files (rapidastconfig.yaml, kdo-cr.yaml, rapidast-job.yaml). Set to a PR branch for pre-merge testing."
+      default: "main"
+      type: string
   tasks:
     # ──────────────────────────────────────────────────────────────────────────
     # Task 1: parse-metadata
@@ -191,7 +195,7 @@ spec:
               set -euxo pipefail
 
               export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
-              export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/latest/download
+              export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.42.2
               curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_linux_${ARCH}
               chmod +x operator-sdk_linux_${ARCH}
               mv operator-sdk_linux_${ARCH} /usr/local/bin/operator-sdk
@@ -228,10 +232,14 @@ spec:
           value: $(params.SNAPSHOT)
         - name: kdo_version
           value: $(params.kdo_version)
+        - name: config_git_revision
+          value: $(params.config_git_revision)
       taskSpec:
         params:
           - name: SNAPSHOT
           - name: kdo_version
+            type: string
+          - name: config_git_revision
             type: string
         results:
           - name: TEST_OUTPUT
@@ -274,6 +282,8 @@ spec:
                 value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
               - name: KDO_VERSION
                 value: "$(params.kdo_version)"
+              - name: CONFIG_GIT_REVISION
+                value: "$(params.config_git_revision)"
             volumeMounts:
               - name: credentials
                 mountPath: /credentials
@@ -300,7 +310,7 @@ spec:
                 --dry-run=client -o yaml | kubectl apply -f -
 
               # --- 3. Fetch config files from repo ---
-              REPO_RAW="https://raw.githubusercontent.com/openshift/cluster-kube-descheduler-operator/main"
+              REPO_RAW="https://raw.githubusercontent.com/openshift/cluster-kube-descheduler-operator/${CONFIG_GIT_REVISION}"
               CONFIG_DIR=".tekton/integration-tests/configs"
               curl -sfL "${REPO_RAW}/${CONFIG_DIR}/rapidastconfig.yaml" > /tmp/rapidastconfig.yaml
               curl -sfL "${REPO_RAW}/${CONFIG_DIR}/kdo-cr.yaml" > /tmp/kdo-cr.yaml

--- a/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
+++ b/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
@@ -20,7 +20,7 @@ spec:
       type: string
     - name: config_git_revision
       description: "Git branch/revision used to fetch config files (rapidastconfig.yaml, kdo-cr.yaml, rapidast-job.yaml). Set to a PR branch for pre-merge testing."
-      default: "dast-pipeline-kdo-4-21"
+      default: "main"
       type: string
   tasks:
     # ──────────────────────────────────────────────────────────────────────────
@@ -315,7 +315,7 @@ spec:
                 --dry-run=client -o yaml | oc apply -f -
 
               # --- 3. Fetch config files from repo ---
-              REPO_RAW="https://raw.githubusercontent.com/thedeveloper-ctl/cluster-kube-descheduler-operator/${CONFIG_GIT_REVISION}"
+              REPO_RAW="https://raw.githubusercontent.com/openshift/cluster-kube-descheduler-operator/${CONFIG_GIT_REVISION}"
               CONFIG_DIR=".tekton/integration-tests/configs"
               curl -sfL "${REPO_RAW}/${CONFIG_DIR}/rapidastconfig.yaml" > /tmp/rapidastconfig.yaml
               curl -sfL "${REPO_RAW}/${CONFIG_DIR}/kdo-cr.yaml" > /tmp/kdo-cr.yaml

--- a/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
+++ b/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
@@ -315,7 +315,7 @@ spec:
                 --dry-run=client -o yaml | oc apply -f -
 
               # --- 3. Fetch config files from repo ---
-              REPO_RAW="https://raw.githubusercontent.com/openshift/cluster-kube-descheduler-operator/${CONFIG_GIT_REVISION}"
+              REPO_RAW="https://raw.githubusercontent.com/thedeveloper-ctl/cluster-kube-descheduler-operator/${CONFIG_GIT_REVISION}"
               CONFIG_DIR=".tekton/integration-tests/configs"
               curl -sfL "${REPO_RAW}/${CONFIG_DIR}/rapidastconfig.yaml" > /tmp/rapidastconfig.yaml
               curl -sfL "${REPO_RAW}/${CONFIG_DIR}/kdo-cr.yaml" > /tmp/kdo-cr.yaml

--- a/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
+++ b/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
@@ -134,13 +134,13 @@ spec:
                 value: |
                   - source: registry.redhat.io/kube-descheduler-operator/kube-descheduler-rhel9-operator
                     mirrors:
-                      - quay.io/redhat-user-workloads/kdo-workloads-tenant/kube-descheduler-operator
+                      - quay.io/redhat-user-workloads/kdo-workloads-tenant/kube-descheduler-operator-4-21
                   - source: registry.redhat.io/kube-descheduler-operator/descheduler-rhel9
                     mirrors:
-                      - quay.io/redhat-user-workloads/kdo-workloads-tenant/kube-descheduler-operator
+                      - quay.io/redhat-user-workloads/kdo-workloads-tenant/descheduler-4-21
                   - source: registry.redhat.io/kube-descheduler-operator/kube-descheduler-operator-bundle
                     mirrors:
-                      - quay.io/redhat-user-workloads/kdo-workloads-tenant/kube-descheduler-operator-bundle
+                      - quay.io/redhat-user-workloads/kdo-workloads-tenant/kube-descheduler-operator-bundle-4-21
 
     # ──────────────────────────────────────────────────────────────────────────
     # Task 4: install-kdo-operator (from SNAPSHOT bundle via operator-sdk)

--- a/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
+++ b/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
@@ -321,8 +321,7 @@ spec:
               curl -sfL "${REPO_RAW}/${CONFIG_DIR}/kdo-cr.yaml" > /tmp/kdo-cr.yaml
 
               # Expand ${KDO_VERSION} in the RapiDAST config
-              export KDO_VERSION
-              envsubst '${KDO_VERSION}' < /tmp/rapidastconfig.yaml > /tmp/rapidastconfig-resolved.yaml
+              sed "s/\${KDO_VERSION}/${KDO_VERSION}/g" /tmp/rapidastconfig.yaml > /tmp/rapidastconfig-resolved.yaml
 
               # --- 4. Create PVC for results on ephemeral cluster ---
               cat <<'PVCEOF' | oc apply -f -

--- a/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
+++ b/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
@@ -328,7 +328,7 @@ spec:
 
               # Expand ${KDO_VERSION} in the RapiDAST config
               export KDO_VERSION
-              envsubst '${KDO_VERSION}' < /tmp/rapidastconfig.yaml > /tmp/rapidastconfig-resolved.yaml
+              sed "s/\${KDO_VERSION}/${KDO_VERSION}/g" /tmp/rapidastconfig.yaml > /tmp/rapidastconfig-resolved.yaml
 
               # --- 4. Create PVC for results on ephemeral cluster ---
               cat <<'PVCEOF' | oc apply -f -

--- a/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
+++ b/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
@@ -107,7 +107,7 @@ spec:
                   value: stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
             params:
               - name: prefix
-                value: "4.21."
+                value: "4.20."
           - name: create-cluster
             ref:
               resolver: git

--- a/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
+++ b/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
@@ -146,7 +146,7 @@ spec:
     # Task 4: install-kdo-operator (from SNAPSHOT bundle via operator-sdk)
     # ──────────────────────────────────────────────────────────────────────────
     - name: install-kdo-operator
-      timeout: "15m"
+      timeout: "5m"
       runAfter:
         - provision-cluster
       when:
@@ -224,7 +224,7 @@ spec:
     # Task 5: dast-test (oobtkube Job + Trivy + post-process)
     # ──────────────────────────────────────────────────────────────────────────
     - name: dast-test
-      timeout: "20m"
+      timeout: "10m"
       description: DAST testing with RapiDAST oobtkube and Trivy misconfiguration scan
       runAfter:
         - install-kdo-operator
@@ -251,12 +251,6 @@ spec:
             description: Tekton task test output.
           - name: SCAN_OUTPUT
             description: DAST scan result.
-          - name: OOBTKUBE_SARIF
-            description: Raw oobtkube SARIF results (truncated to 4KB if needed).
-          - name: TRIVY_JSON
-            description: Raw Trivy misconfiguration JSON results (truncated to 4KB if needed).
-          - name: RAPIDAST_LOG
-            description: RapiDAST Job logs (truncated to 4KB if needed).
         volumes:
           - name: credentials
             emptyDir: {}
@@ -385,7 +379,7 @@ spec:
               spec:
                 containers:
                   - name: fetcher
-                    image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+                    image: registry.access.redhat.com/ubi9/ubi:latest
                     command: ["sleep", "300"]
                     volumeMounts:
                       - name: results
@@ -449,25 +443,6 @@ spec:
               fi
 
               echo "$scan_result" | tee "$(results.SCAN_OUTPUT.path)"
-
-              # --- Write raw scan artifacts (truncated to 4KB for Tekton limit) ---
-              truncate_to_result() {
-                local file="$1" dest="$2" limit=4096
-                if [ -s "$file" ]; then
-                  if [ "$(wc -c < "$file")" -gt "$limit" ]; then
-                    head -c $limit "$file" > "$dest"
-                    echo -e "\n... [TRUNCATED - full results in GCS]" >> "$dest"
-                  else
-                    cp "$file" "$dest"
-                  fi
-                else
-                  echo "No results collected" > "$dest"
-                fi
-              }
-
-              truncate_to_result /shared/oobtkube-results.sarif "$(results.OOBTKUBE_SARIF.path)"
-              truncate_to_result /shared/trivy-results.json "$(results.TRIVY_JSON.path)"
-              truncate_to_result /shared/rapidast-kdo-log.txt "$(results.RAPIDAST_LOG.path)"
 
               note="Task $(context.task.name) completed: Refer to SCAN_OUTPUT for DAST findings."
               TEST_OUTPUT=$(make_result_json -r "SUCCESS" -t "$note")

--- a/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
+++ b/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
@@ -217,7 +217,7 @@ spec:
 
               oc wait --for condition=Available \
                 -n openshift-kube-descheduler-operator \
-                deployment -l name=descheduler-operator \
+                deployment/descheduler-operator \
                 --timeout=120s
 
     # ──────────────────────────────────────────────────────────────────────────
@@ -352,7 +352,7 @@ spec:
               sleep 15
               kubectl wait --for condition=Available \
                 -n openshift-kube-descheduler-operator \
-                deployment -l name=descheduler-operator \
+                deployment/descheduler-operator \
                 --timeout=120s
 
               # --- 7. Create RapiDAST Job on ephemeral cluster ---

--- a/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
+++ b/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
@@ -27,6 +27,7 @@ spec:
     # Task 1: parse-metadata
     # ──────────────────────────────────────────────────────────────────────────
     - name: parse-metadata
+      timeout: "5m"
       taskRef:
         resolver: git
         params:
@@ -44,6 +45,7 @@ spec:
     # Task 2: eaas-provision-space
     # ──────────────────────────────────────────────────────────────────────────
     - name: eaas-provision-space
+      timeout: "5m"
       runAfter:
         - parse-metadata
       when:
@@ -71,6 +73,7 @@ spec:
     # Task 3: provision-cluster (OCP 4.21 + imageContentSources for KDO)
     # ──────────────────────────────────────────────────────────────────────────
     - name: provision-cluster
+      timeout: "35m"
       runAfter:
         - eaas-provision-space
       when:
@@ -126,7 +129,7 @@ spec:
               - name: instanceType
                 value: "m5.xlarge"
               - name: timeout
-                value: "40m"
+                value: "30m"
               - name: imageContentSources
                 value: |
                   - source: registry.redhat.io/kube-descheduler-operator/kube-descheduler-rhel9-operator
@@ -143,6 +146,7 @@ spec:
     # Task 4: install-kdo-operator (from SNAPSHOT bundle via operator-sdk)
     # ──────────────────────────────────────────────────────────────────────────
     - name: install-kdo-operator
+      timeout: "15m"
       runAfter:
         - provision-cluster
       when:
@@ -207,7 +211,7 @@ spec:
 
               oc create namespace openshift-kube-descheduler-operator || true
 
-              operator-sdk run bundle --timeout=5m \
+              operator-sdk run bundle --timeout=10m \
                 --namespace openshift-kube-descheduler-operator \
                 "$BUNDLE_IMAGE" --verbose
 
@@ -220,6 +224,7 @@ spec:
     # Task 5: dast-test (oobtkube Job + Trivy + post-process)
     # ──────────────────────────────────────────────────────────────────────────
     - name: dast-test
+      timeout: "20m"
       description: DAST testing with RapiDAST oobtkube and Trivy misconfiguration scan
       runAfter:
         - install-kdo-operator

--- a/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
+++ b/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
@@ -1,0 +1,438 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: kube-descheduler-operator-dast-pipeline
+spec:
+  description: |
+    DAST pipeline for Kube Descheduler Operator on Konflux.
+    Provisions an ephemeral OCP 4.21 cluster, installs KDO from SNAPSHOT bundle,
+    runs oobtkube (blind command injection testing via RapiDAST) as a Job on the
+    ephemeral cluster, and Trivy for misconfiguration scanning. Results are uploaded
+    to GCS and surfaced in Konflux UI via TEST_OUTPUT/SCAN_OUTPUT.
+  params:
+    - name: SNAPSHOT
+      description: "The JSON string representing the snapshot of the application under test."
+      default: '{"components": [{"name":"test-app", "containerImage": "quay.io/example/repo:latest"}]}'
+      type: string
+    - name: kdo_version
+      description: "KDO product version used to tag RapiDAST scan results in GCS"
+      type: string
+  tasks:
+    # ──────────────────────────────────────────────────────────────────────────
+    # Task 1: parse-metadata
+    # ──────────────────────────────────────────────────────────────────────────
+    - name: parse-metadata
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/integration-examples
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/test_metadata.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Task 2: eaas-provision-space
+    # ──────────────────────────────────────────────────────────────────────────
+    - name: eaas-provision-space
+      runAfter:
+        - parse-metadata
+      when:
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: ["push", "Push", "PUSH", "incoming", "Incoming", "INCOMING"]
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
+      params:
+        - name: ownerKind
+          value: PipelineRun
+        - name: ownerName
+          value: $(context.pipelineRun.name)
+        - name: ownerUid
+          value: $(context.pipelineRun.uid)
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Task 3: provision-cluster (OCP 4.21 + imageContentSources for KDO)
+    # ──────────────────────────────────────────────────────────────────────────
+    - name: provision-cluster
+      runAfter:
+        - eaas-provision-space
+      when:
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: ["push", "Push", "PUSH", "incoming", "Incoming", "INCOMING"]
+      taskSpec:
+        results:
+          - name: clusterName
+            value: "$(steps.create-cluster.results.clusterName)"
+        steps:
+          - name: get-supported-versions
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-supported-ephemeral-cluster-versions/0.1/eaas-get-supported-ephemeral-cluster-versions.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+          - name: pick-version
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
+            params:
+              - name: prefix
+                value: "4.21."
+          - name: create-cluster
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: version
+                value: "$(steps.pick-version.results.version)"
+              - name: instanceType
+                value: "m5.xlarge"
+              - name: timeout
+                value: "30m"
+              - name: imageContentSources
+                value: |
+                  - source: registry.redhat.io/kube-descheduler-operator/kube-descheduler-rhel9-operator
+                    mirrors:
+                      - quay.io/redhat-user-workloads/kdo-workloads-tenant/kube-descheduler-operator
+                  - source: registry.redhat.io/kube-descheduler-operator/descheduler-rhel9
+                    mirrors:
+                      - quay.io/redhat-user-workloads/kdo-workloads-tenant/kube-descheduler-operator
+                  - source: registry.redhat.io/kube-descheduler-operator/kube-descheduler-operator-bundle
+                    mirrors:
+                      - quay.io/redhat-user-workloads/kdo-workloads-tenant/kube-descheduler-operator-bundle
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Task 4: install-kdo-operator (from SNAPSHOT bundle via operator-sdk)
+    # ──────────────────────────────────────────────────────────────────────────
+    - name: install-kdo-operator
+      runAfter:
+        - provision-cluster
+      when:
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: ["push", "Push", "PUSH", "incoming", "Incoming", "INCOMING"]
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+      taskSpec:
+        params:
+          - name: SNAPSHOT
+        volumes:
+          - name: credentials
+            emptyDir: {}
+        steps:
+          - name: get-kubeconfig
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: clusterName
+                value: "$(tasks.provision-cluster.results.clusterName)"
+              - name: credentials
+                value: credentials
+          - name: install-operator
+            image: quay.io/konflux-ci/konflux-test:latest
+            env:
+              - name: SNAPSHOT
+                value: $(params.SNAPSHOT)
+              - name: KONFLUX_COMPONENT_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.labels['appstudio.openshift.io/component']
+              - name: KUBECONFIG
+                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+            volumeMounts:
+              - name: credentials
+                mountPath: /credentials
+            script: |
+              #!/bin/bash
+              set -euxo pipefail
+
+              export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
+              export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/latest/download
+              curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_linux_${ARCH}
+              chmod +x operator-sdk_linux_${ARCH}
+              mv operator-sdk_linux_${ARCH} /usr/local/bin/operator-sdk
+
+              echo "KONFLUX_COMPONENT_NAME: ${KONFLUX_COMPONENT_NAME}"
+              BUNDLE_IMAGE="$(jq -r --arg component_name "$KONFLUX_COMPONENT_NAME" \
+                '.components[] | select(.name == $component_name) | .containerImage' <<< "$SNAPSHOT")"
+              echo "BUNDLE_IMAGE: ${BUNDLE_IMAGE}"
+
+              oc create namespace openshift-kube-descheduler-operator || true
+
+              operator-sdk run bundle --timeout=5m \
+                --namespace openshift-kube-descheduler-operator \
+                "$BUNDLE_IMAGE" --verbose
+
+              oc wait --for condition=Available \
+                -n openshift-kube-descheduler-operator \
+                deployment -l app.kubernetes.io/name=kube-descheduler-operator \
+                --timeout=120s
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Task 5: dast-test (oobtkube Job + Trivy + post-process)
+    # ──────────────────────────────────────────────────────────────────────────
+    - name: dast-test
+      description: DAST testing with RapiDAST oobtkube and Trivy misconfiguration scan
+      runAfter:
+        - install-kdo-operator
+      when:
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: ["push", "Push", "PUSH", "incoming", "Incoming", "INCOMING"]
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: kdo_version
+          value: $(params.kdo_version)
+      taskSpec:
+        params:
+          - name: SNAPSHOT
+          - name: kdo_version
+            type: string
+        results:
+          - name: TEST_OUTPUT
+            description: Tekton task test output.
+          - name: SCAN_OUTPUT
+            description: DAST scan result.
+        volumes:
+          - name: credentials
+            emptyDir: {}
+          - name: gcs-key
+            secret:
+              secretName: rapidast-sa-kdo-key
+          - name: shared
+            emptyDir: {}
+        steps:
+          # Step 5a: Get kubeconfig for ephemeral cluster
+          - name: get-kubeconfig
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: clusterName
+                value: "$(tasks.provision-cluster.results.clusterName)"
+              - name: credentials
+                value: credentials
+
+          # Step 5b: Orchestrate oobtkube DAST on ephemeral cluster
+          - name: orchestrate-dast
+            image: quay.io/konflux-ci/konflux-test:latest
+            env:
+              - name: KUBECONFIG
+                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+              - name: KDO_VERSION
+                value: "$(params.kdo_version)"
+            volumeMounts:
+              - name: credentials
+                mountPath: /credentials
+              - name: gcs-key
+                mountPath: /etc/gcs
+                readOnly: true
+              - name: shared
+                mountPath: /shared
+            script: |
+              #!/bin/bash
+              set -euxo pipefail
+              trap 'echo "DAST orchestration failed"; exit 1' ERR
+
+              # --- 1. Create namespace and RBAC on ephemeral cluster ---
+              kubectl create namespace rapidast-kdo
+              kubectl create sa privileged-sa -n rapidast-kdo
+              kubectl create clusterrolebinding rapidast-privileged \
+                --clusterrole=cluster-admin --serviceaccount=rapidast-kdo:privileged-sa
+
+              # --- 2. Propagate GCS secret to ephemeral cluster ---
+              kubectl create secret generic rapidast-sa-kdo-key \
+                --from-file=sa-key=/etc/gcs/sa-key \
+                --namespace=rapidast-kdo \
+                --dry-run=client -o yaml | kubectl apply -f -
+
+              # --- 3. Fetch config files from repo ---
+              REPO_RAW="https://raw.githubusercontent.com/openshift/cluster-kube-descheduler-operator/main"
+              CONFIG_DIR=".tekton/integration-tests/configs"
+              curl -sfL "${REPO_RAW}/${CONFIG_DIR}/rapidastconfig.yaml" > /tmp/rapidastconfig.yaml
+              curl -sfL "${REPO_RAW}/${CONFIG_DIR}/kdo-cr.yaml" > /tmp/kdo-cr.yaml
+
+              # Expand ${KDO_VERSION} in the RapiDAST config
+              export KDO_VERSION
+              envsubst '${KDO_VERSION}' < /tmp/rapidastconfig.yaml > /tmp/rapidastconfig-resolved.yaml
+
+              # --- 4. Create PVC for results on ephemeral cluster ---
+              cat <<'PVCEOF' | kubectl apply -f -
+              apiVersion: v1
+              kind: PersistentVolumeClaim
+              metadata:
+                name: rapidast-pvc
+                namespace: rapidast-kdo
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 1Gi
+              PVCEOF
+
+              # --- 5. Create RapiDAST ConfigMap from fetched config files ---
+              kubectl create configmap rapidast-kdo-config \
+                --from-file=rapidastconfig.yaml=/tmp/rapidastconfig-resolved.yaml \
+                --from-file=kdo-cr.yaml=/tmp/kdo-cr.yaml \
+                --namespace=rapidast-kdo
+
+              # --- 6. Apply enriched CR on ephemeral cluster (for operator to reconcile) ---
+              kubectl apply -f /tmp/kdo-cr.yaml
+
+              # Wait for operator to reconcile the CR
+              sleep 15
+              kubectl wait --for condition=Available \
+                -n openshift-kube-descheduler-operator \
+                deployment -l app.kubernetes.io/name=kube-descheduler-operator \
+                --timeout=120s
+
+              # --- 7. Create RapiDAST Job on ephemeral cluster ---
+              curl -sfL "${REPO_RAW}/${CONFIG_DIR}/rapidast-job.yaml" > /tmp/rapidast-job.yaml
+              kubectl apply -f /tmp/rapidast-job.yaml
+
+              # --- 8. Wait for Job to terminate (complete or fail) ---
+              kubectl wait --for=condition=complete job/rapidast-kdo-oobtkube \
+                -n rapidast-kdo --timeout=600s 2>/dev/null \
+                || kubectl wait --for=condition=failed job/rapidast-kdo-oobtkube \
+                -n rapidast-kdo --timeout=30s 2>/dev/null \
+                || echo "Job still running after timeout"
+
+              # --- 9. Capture Job logs ---
+              kubectl logs job/rapidast-kdo-oobtkube -n rapidast-kdo > /shared/rapidast-kdo-log.txt 2>&1 || true
+
+              # --- 10. Retrieve SARIF from PVC via helper pod ---
+              cat <<'CPEOF' | kubectl apply -f -
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: results-fetcher
+                namespace: rapidast-kdo
+              spec:
+                containers:
+                  - name: fetcher
+                    image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+                    command: ["sleep", "300"]
+                    volumeMounts:
+                      - name: results
+                        mountPath: /results
+                volumes:
+                  - name: results
+                    persistentVolumeClaim:
+                      claimName: rapidast-pvc
+                restartPolicy: Never
+              CPEOF
+              kubectl wait --for=condition=Ready pod/results-fetcher -n rapidast-kdo --timeout=60s
+              kubectl cp rapidast-kdo/results-fetcher:/results/oobtkube-results.sarif /shared/oobtkube-results.sarif || true
+
+              echo "DAST orchestration complete. Results in /shared/"
+
+          # Step 5c: Run Trivy misconfiguration scan
+          - name: run-trivy
+            image: quay.io/redhatproductsecurity/rapidast:latest
+            env:
+              - name: KUBECONFIG
+                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+            volumeMounts:
+              - name: credentials
+                mountPath: /credentials
+              - name: shared
+                mountPath: /shared
+            script: |
+              #!/bin/bash
+              set -euxo pipefail
+
+              trivy k8s --report summary --severity HIGH,CRITICAL \
+                --include-namespaces openshift-kube-descheduler-operator \
+                --format json --output /shared/trivy-results.json \
+                --kubeconfig "$KUBECONFIG"
+
+              echo "Trivy scan complete"
+
+          # Step 5d: Post-process results for Konflux UI
+          - name: post-process
+            image: quay.io/konflux-ci/konflux-test:latest
+            volumeMounts:
+              - name: shared
+                mountPath: /shared
+            script: |
+              #!/bin/bash
+              source /utils.sh
+              trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+              scan_result='{"vulnerabilities":{"critical":0,"high":0,"medium":0,"low":0,"unknown":0}}'
+
+              sarif_file=/shared/oobtkube-results.sarif
+              if [ -s "$sarif_file" ]; then
+              result=$(jq -rce '{
+                vulnerabilities:{
+                  critical: ([.runs[0].results[]? | select(.level == "error")] | length),
+                  high: ([.runs[0].results[]? | select(.level == "warning")] | length),
+                  medium: ([.runs[0].results[]? | select(.level == "note")] | length),
+                  low: ([.runs[0].results[]? | select(.level == "none" or .level == null or .level == "")] | length),
+                  unknown: ([.runs[0].results[]? | select(.level != "error" and .level != "warning" and .level != "note" and .level != "none" and .level != null and .level != "")] | length)
+                }}' "$sarif_file")
+                scan_result=$(jq -s -rce '.[0].vulnerabilities.critical += .[1].vulnerabilities.critical |
+                  .[0].vulnerabilities.high += .[1].vulnerabilities.high |
+                  .[0].vulnerabilities.medium += .[1].vulnerabilities.medium |
+                  .[0]' <<<"$scan_result $result")
+              fi
+
+              echo "$scan_result" | tee "$(results.SCAN_OUTPUT.path)"
+
+              note="Task $(context.task.name) completed: Refer to SCAN_OUTPUT for DAST findings."
+              TEST_OUTPUT=$(make_result_json -r "SUCCESS" -t "$note")
+              echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"

--- a/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
+++ b/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
@@ -20,7 +20,7 @@ spec:
       type: string
     - name: config_git_revision
       description: "Git branch/revision used to fetch config files (rapidastconfig.yaml, kdo-cr.yaml, rapidast-job.yaml). Set to a PR branch for pre-merge testing."
-      default: "main"
+      default: "dast-pipeline-kdo-4-21"
       type: string
   tasks:
     # ──────────────────────────────────────────────────────────────────────────

--- a/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
+++ b/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
@@ -321,7 +321,8 @@ spec:
               curl -sfL "${REPO_RAW}/${CONFIG_DIR}/kdo-cr.yaml" > /tmp/kdo-cr.yaml
 
               # Expand ${KDO_VERSION} in the RapiDAST config
-              sed "s/\${KDO_VERSION}/${KDO_VERSION}/g" /tmp/rapidastconfig.yaml > /tmp/rapidastconfig-resolved.yaml
+              export KDO_VERSION
+              envsubst '${KDO_VERSION}' < /tmp/rapidastconfig.yaml > /tmp/rapidastconfig-resolved.yaml
 
               # --- 4. Create PVC for results on ephemeral cluster ---
               cat <<'PVCEOF' | oc apply -f -
@@ -391,32 +392,11 @@ spec:
               CPEOF
               oc wait --for=condition=Ready pod/results-fetcher -n rapidast-kdo --timeout=60s
               oc cp rapidast-kdo/results-fetcher:/results/oobtkube-results.sarif /shared/oobtkube-results.sarif || true
+              oc cp rapidast-kdo/results-fetcher:/results/trivy-results.json /shared/trivy-results.json || true
 
               echo "DAST orchestration complete. Results in /shared/"
 
-          # Step 5c: Run Trivy misconfiguration scan
-          - name: run-trivy
-            image: quay.io/redhatproductsecurity/rapidast:latest
-            env:
-              - name: KUBECONFIG
-                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
-            volumeMounts:
-              - name: credentials
-                mountPath: /credentials
-              - name: shared
-                mountPath: /shared
-            script: |
-              #!/bin/bash
-              set -euxo pipefail
-
-              trivy k8s --report summary --severity HIGH,CRITICAL \
-                --include-namespaces openshift-kube-descheduler-operator \
-                --format json --output /shared/trivy-results.json \
-                --kubeconfig "$KUBECONFIG"
-
-              echo "Trivy scan complete"
-
-          # Step 5d: Post-process results for Konflux UI
+          # Step 5c: Post-process results for Konflux UI
           - name: post-process
             image: quay.io/konflux-ci/konflux-test:latest
             volumeMounts:
@@ -429,20 +409,37 @@ spec:
 
               scan_result='{"vulnerabilities":{"critical":0,"high":0,"medium":0,"low":0,"unknown":0}}'
 
+              # --- Parse oobtkube SARIF results ---
               sarif_file=/shared/oobtkube-results.sarif
               if [ -s "$sarif_file" ]; then
-              result=$(jq -rce '{
-                vulnerabilities:{
-                  critical: ([.runs[0].results[]? | select(.level == "error")] | length),
-                  high: ([.runs[0].results[]? | select(.level == "warning")] | length),
-                  medium: ([.runs[0].results[]? | select(.level == "note")] | length),
-                  low: ([.runs[0].results[]? | select(.level == "none" or .level == null or .level == "")] | length),
-                  unknown: ([.runs[0].results[]? | select(.level != "error" and .level != "warning" and .level != "note" and .level != "none" and .level != null and .level != "")] | length)
-                }}' "$sarif_file")
+                result=$(jq -rce '{
+                  vulnerabilities:{
+                    critical: ([.runs[0].results[]? | select(.level == "error")] | length),
+                    high: ([.runs[0].results[]? | select(.level == "warning")] | length),
+                    medium: ([.runs[0].results[]? | select(.level == "note")] | length),
+                    low: ([.runs[0].results[]? | select(.level == "none" or .level == null or .level == "")] | length),
+                    unknown: ([.runs[0].results[]? | select(.level != "error" and .level != "warning" and .level != "note" and .level != "none" and .level != null and .level != "")] | length)
+                  }}' "$sarif_file")
                 scan_result=$(jq -s -rce '.[0].vulnerabilities.critical += .[1].vulnerabilities.critical |
                   .[0].vulnerabilities.high += .[1].vulnerabilities.high |
                   .[0].vulnerabilities.medium += .[1].vulnerabilities.medium |
                   .[0]' <<<"$scan_result $result")
+              fi
+
+              # --- Parse Trivy JSON results ---
+              trivy_file=/shared/trivy-results.json
+              if [ -s "$trivy_file" ]; then
+                trivy_result=$(jq -rce '{
+                  vulnerabilities:{
+                    critical: ([.Resources[]?.Results[]?.Misconfigurations[]? | select(.Severity == "CRITICAL")] | length),
+                    high: ([.Resources[]?.Results[]?.Misconfigurations[]? | select(.Severity == "HIGH")] | length),
+                    medium: 0,
+                    low: 0,
+                    unknown: 0
+                  }}' "$trivy_file")
+                scan_result=$(jq -s -rce '.[0].vulnerabilities.critical += .[1].vulnerabilities.critical |
+                  .[0].vulnerabilities.high += .[1].vulnerabilities.high |
+                  .[0]' <<<"$scan_result $trivy_result")
               fi
 
               echo "$scan_result" | tee "$(results.SCAN_OUTPUT.path)"

--- a/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
+++ b/.tekton/integration-tests/pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml
@@ -217,7 +217,7 @@ spec:
 
               oc wait --for condition=Available \
                 -n openshift-kube-descheduler-operator \
-                deployment -l app.kubernetes.io/name=kube-descheduler-operator \
+                deployment -l name=descheduler-operator \
                 --timeout=120s
 
     # ──────────────────────────────────────────────────────────────────────────
@@ -352,7 +352,7 @@ spec:
               sleep 15
               kubectl wait --for condition=Available \
                 -n openshift-kube-descheduler-operator \
-                deployment -l app.kubernetes.io/name=kube-descheduler-operator \
+                deployment -l name=descheduler-operator \
                 --timeout=120s
 
               # --- 7. Create RapiDAST Job on ephemeral cluster ---

--- a/.tekton/integration-tests/scripts/test-dast-on-crc.sh
+++ b/.tekton/integration-tests/scripts/test-dast-on-crc.sh
@@ -1,0 +1,451 @@
+#!/bin/bash
+#
+# Test KDO DAST pipeline locally on CRC.
+# Simulates the Konflux integration test pipeline without Tekton/EaaS.
+#
+# Prerequisites:
+#   - CRC running: crc start
+#   - Logged in:   eval $(crc console --credentials) && oc login ...
+#
+# Usage:
+#   ./test-dast-on-crc.sh [BUNDLE_IMAGE]
+#
+# If BUNDLE_IMAGE is omitted, the script installs KDO from OperatorHub instead.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIGS_DIR="${SCRIPT_DIR}/../configs"
+KDO_VERSION="4.21"
+KDO_NAMESPACE="openshift-kube-descheduler-operator"
+DAST_NAMESPACE="rapidast-kdo"
+BUNDLE_IMAGE="${1:-}"
+RESULTS_DIR="/tmp/kdo-dast-results"
+OOBTKUBE_DURATION="${OOBTKUBE_DURATION:-60}"
+
+header() { echo -e "\n\033[1;36m=== $1 ===\033[0m"; }
+ok()     { echo -e "\033[1;32m✓ $1\033[0m"; }
+fail()   { echo -e "\033[1;31m✗ $1\033[0m"; }
+
+cleanup() {
+    header "Cleanup"
+    echo "Cleaning up test resources..."
+    oc delete namespace "${DAST_NAMESPACE}" --ignore-not-found --wait=false 2>/dev/null || true
+    oc delete clusterrolebinding rapidast-privileged --ignore-not-found 2>/dev/null || true
+    if [ -n "${BUNDLE_IMAGE}" ]; then
+        operator-sdk cleanup kube-descheduler-operator \
+            --namespace "${KDO_NAMESPACE}" 2>/dev/null || true
+    fi
+    oc delete namespace "${KDO_NAMESPACE}" --ignore-not-found --wait=false 2>/dev/null || true
+    oc delete imagedigestmirrorset kdo-konflux-mirrors --ignore-not-found 2>/dev/null || true
+    ok "Cleanup complete"
+}
+
+trap cleanup EXIT
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 1: Verify CRC is running
+# ─────────────────────────────────────────────────────────────────────────────
+header "Phase 1: Verify CRC"
+if ! oc whoami &>/dev/null; then
+    fail "Not logged into OpenShift. Run: eval \$(crc console --credentials)"
+    exit 1
+fi
+CLUSTER_VERSION=$(oc get clusterversion version -o jsonpath='{.status.desired.version}' 2>/dev/null || echo "unknown")
+ok "Connected to CRC (OCP ${CLUSTER_VERSION}) as $(oc whoami)"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 2: Install operator-sdk (if not present)
+# ─────────────────────────────────────────────────────────────────────────────
+header "Phase 2: Install operator-sdk"
+if command -v operator-sdk &>/dev/null; then
+    ok "operator-sdk already installed: $(operator-sdk version | head -1)"
+else
+    echo "Downloading operator-sdk..."
+    MACHINE=$(uname -m)
+    case "${MACHINE}" in
+        x86_64)       ARCH="amd64" ;;
+        arm64|aarch64) ARCH="arm64" ;;
+        *)            ARCH="${MACHINE}" ;;
+    esac
+    OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+    LOCAL_BIN="${HOME}/.local/bin"
+    mkdir -p "${LOCAL_BIN}"
+    OPERATOR_SDK_DL_URL="https://github.com/operator-framework/operator-sdk/releases/latest/download"
+    curl -sLO "${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}"
+    chmod +x "operator-sdk_${OS}_${ARCH}"
+    mv "operator-sdk_${OS}_${ARCH}" "${LOCAL_BIN}/operator-sdk"
+    export PATH="${LOCAL_BIN}:${PATH}"
+    ok "operator-sdk installed to ${LOCAL_BIN}: $(operator-sdk version | head -1)"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 3: Install KDO operator
+# ─────────────────────────────────────────────────────────────────────────────
+header "Phase 3: Install KDO operator"
+
+# Mirror registry.redhat.io images to Konflux Quay builds (same as pipeline imageContentSources)
+cat <<'MIRROREOF' | oc apply -f -
+apiVersion: config.openshift.io/v1
+kind: ImageDigestMirrorSet
+metadata:
+  name: kdo-konflux-mirrors
+spec:
+  imageDigestMirrors:
+    - source: registry.redhat.io/kube-descheduler-operator/kube-descheduler-rhel9-operator
+      mirrors:
+        - quay.io/redhat-user-workloads/kdo-workloads-tenant/kube-descheduler-operator-4-21
+    - source: registry.redhat.io/kube-descheduler-operator/descheduler-rhel9
+      mirrors:
+        - quay.io/redhat-user-workloads/kdo-workloads-tenant/kube-descheduler-operator-4-21
+    - source: registry.redhat.io/kube-descheduler-operator/kube-descheduler-operator-bundle
+      mirrors:
+        - quay.io/redhat-user-workloads/kdo-workloads-tenant/kube-descheduler-operator-bundle-4-21
+MIRROREOF
+echo "Waiting for ImageDigestMirrorSet to propagate (CRC node may restart)..."
+for i in $(seq 1 24); do
+    if oc get nodes 2>/dev/null | grep -q " Ready"; then
+        break
+    fi
+    echo "  Node not ready yet (attempt ${i}/24)..."
+    sleep 10
+done
+sleep 10
+ok "Mirror set applied, node is Ready"
+
+oc create namespace "${KDO_NAMESPACE}" 2>/dev/null || true
+
+if [ -n "${BUNDLE_IMAGE}" ]; then
+    echo "Installing from bundle: ${BUNDLE_IMAGE}"
+
+    # Pre-create OperatorGroup so OLM sees it before the CSV lands
+    cat <<OGEOF | oc apply -f -
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: kdo-og
+  namespace: ${KDO_NAMESPACE}
+spec:
+  targetNamespaces:
+    - ${KDO_NAMESPACE}
+OGEOF
+    sleep 5
+
+    operator-sdk run bundle --timeout=10m \
+        --namespace "${KDO_NAMESPACE}" \
+        --skip-tls-verify \
+        "${BUNDLE_IMAGE}" --verbose
+else
+    echo "No bundle image provided. Installing from OperatorHub..."
+    cat <<'EOF' | oc apply -f -
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: kdo-og
+  namespace: openshift-kube-descheduler-operator
+spec:
+  targetNamespaces:
+    - openshift-kube-descheduler-operator
+EOF
+    cat <<'EOF' | oc apply -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cluster-kube-descheduler-operator
+  namespace: openshift-kube-descheduler-operator
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: cluster-kube-descheduler-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+    echo "Waiting for operator CSV to succeed..."
+    for i in $(seq 1 30); do
+        CSV=$(oc get csv -n "${KDO_NAMESPACE}" -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "Waiting")
+        if [ "${CSV}" = "Succeeded" ]; then break; fi
+        echo "  CSV status: ${CSV} (attempt ${i}/30)"
+        sleep 10
+    done
+fi
+
+echo "Waiting for operator deployment..."
+# Label may differ between bundle install and OperatorHub; wait for any deployment
+for i in $(seq 1 30); do
+    DEPLOY=$(oc get deployment -n "${KDO_NAMESPACE}" -o name 2>/dev/null | head -1)
+    if [ -n "${DEPLOY}" ]; then
+        echo "  Found: ${DEPLOY}"
+        oc wait --for condition=Available -n "${KDO_NAMESPACE}" "${DEPLOY}" --timeout=180s
+        break
+    fi
+    echo "  No deployment yet (attempt ${i}/30)"
+    sleep 10
+done
+if [ -z "${DEPLOY:-}" ]; then
+    fail "No operator deployment found in ${KDO_NAMESPACE}"
+    exit 1
+fi
+ok "KDO operator is running"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 4: Prepare config files
+# ─────────────────────────────────────────────────────────────────────────────
+header "Phase 4: Prepare config files"
+mkdir -p "${RESULTS_DIR}"
+
+if [ ! -f "${CONFIGS_DIR}/rapidastconfig.yaml" ] || [ ! -f "${CONFIGS_DIR}/kdo-cr.yaml" ]; then
+    fail "Config files not found in ${CONFIGS_DIR}"
+    exit 1
+fi
+
+# Strip GCS block for local testing and expand KDO_VERSION
+export KDO_VERSION
+awk '
+BEGIN { skip=0 }
+/^  googleCloudStorage:/ { skip=1; next }
+skip && /^  [a-zA-Z]/ { skip=0 }
+skip && /^[a-zA-Z]/ { skip=0 }
+skip { next }
+{ print }
+' "${CONFIGS_DIR}/rapidastconfig.yaml" | sed "s/-d 300/-d ${OOBTKUBE_DURATION}/" | envsubst '${KDO_VERSION}' > "${RESULTS_DIR}/rapidastconfig.yaml"
+cp "${CONFIGS_DIR}/kdo-cr.yaml" "${RESULTS_DIR}/kdo-cr.yaml"
+ok "Config files ready in ${RESULTS_DIR}"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 5: Create DAST namespace and RBAC
+# ─────────────────────────────────────────────────────────────────────────────
+header "Phase 5: Create DAST namespace + RBAC"
+oc create namespace "${DAST_NAMESPACE}" 2>/dev/null || true
+oc create sa privileged-sa -n "${DAST_NAMESPACE}" 2>/dev/null || true
+oc create clusterrolebinding rapidast-privileged \
+    --clusterrole=cluster-admin \
+    --serviceaccount="${DAST_NAMESPACE}:privileged-sa" 2>/dev/null || true
+ok "Namespace ${DAST_NAMESPACE} ready with cluster-admin SA"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 6: Create PVC + ConfigMap
+# ─────────────────────────────────────────────────────────────────────────────
+header "Phase 6: Create PVC + ConfigMap"
+cat <<EOF | oc apply -f -
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rapidast-pvc
+  namespace: ${DAST_NAMESPACE}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+EOF
+
+oc create configmap rapidast-kdo-config \
+    --from-file=rapidastconfig.yaml="${RESULTS_DIR}/rapidastconfig.yaml" \
+    --from-file=kdo-cr.yaml="${RESULTS_DIR}/kdo-cr.yaml" \
+    --namespace="${DAST_NAMESPACE}" \
+    --dry-run=client -o yaml | oc apply -f -
+ok "PVC and ConfigMap created"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 7: Apply enriched CR
+# ─────────────────────────────────────────────────────────────────────────────
+header "Phase 7: Apply enriched KubeDescheduler CR"
+oc apply -f "${RESULTS_DIR}/kdo-cr.yaml"
+
+echo "Waiting 15s for operator to reconcile..."
+sleep 15
+DEPLOY=$(oc get deployment -n "${KDO_NAMESPACE}" -o name 2>/dev/null | head -1)
+if [ -n "${DEPLOY}" ]; then
+    oc wait --for condition=Available -n "${KDO_NAMESPACE}" "${DEPLOY}" --timeout=120s
+fi
+ok "CR applied and operator reconciled"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 8: Create RapiDAST Job
+# ─────────────────────────────────────────────────────────────────────────────
+header "Phase 8: Launch RapiDAST oobtkube Job"
+cat <<'EOF' | oc apply -f -
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rapidast-kdo-oobtkube
+  namespace: rapidast-kdo
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      serviceAccountName: privileged-sa
+      containers:
+        - name: rapidast
+          image: quay.io/redhatproductsecurity/rapidast:latest
+          imagePullPolicy: Always
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              rapidast.py --log-level debug --config /opt/rapidast/config/rapidastconfig.yaml
+              RESULT=$?
+              cp /opt/rapidast/results/*.sarif /opt/rapidast/pvc-results/ 2>/dev/null || true
+              exit $RESULT
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          volumeMounts:
+            - name: config
+              mountPath: /opt/rapidast/config
+            - name: results
+              mountPath: /opt/rapidast/pvc-results
+      volumes:
+        - name: config
+          configMap:
+            name: rapidast-kdo-config
+        - name: results
+          persistentVolumeClaim:
+            claimName: rapidast-pvc
+      restartPolicy: Never
+EOF
+ok "RapiDAST Job created"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 9: Wait for Job + collect results
+# ─────────────────────────────────────────────────────────────────────────────
+header "Phase 9: Wait for Job completion"
+echo "Tailing Job logs (this can take ~5-10 min)..."
+echo "You can also watch in another terminal: oc logs -f job/rapidast-kdo-oobtkube -n ${DAST_NAMESPACE}"
+echo ""
+
+oc wait --for=condition=complete job/rapidast-kdo-oobtkube \
+    -n "${DAST_NAMESPACE}" --timeout=600s 2>/dev/null \
+    || oc wait --for=condition=failed job/rapidast-kdo-oobtkube \
+    -n "${DAST_NAMESPACE}" --timeout=30s 2>/dev/null \
+    || echo "Job still running after timeout"
+
+JOB_STATUS=$(oc get job rapidast-kdo-oobtkube -n "${DAST_NAMESPACE}" \
+    -o jsonpath='{.status.conditions[0].type}' 2>/dev/null || echo "Unknown")
+echo "Job status: ${JOB_STATUS}"
+
+echo ""
+echo "--- Job logs (last 50 lines) ---"
+oc logs job/rapidast-kdo-oobtkube -n "${DAST_NAMESPACE}" --tail=50 2>/dev/null || true
+echo "--- End logs ---"
+
+header "Phase 9b: Retrieve SARIF from PVC"
+cat <<EOF | oc apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: results-fetcher
+  namespace: ${DAST_NAMESPACE}
+spec:
+  containers:
+    - name: fetcher
+      image: registry.access.redhat.com/ubi9/ubi:latest
+      command: ["sleep", "300"]
+      volumeMounts:
+        - name: results
+          mountPath: /results
+  volumes:
+    - name: results
+      persistentVolumeClaim:
+        claimName: rapidast-pvc
+  restartPolicy: Never
+EOF
+oc wait --for=condition=Ready pod/results-fetcher -n "${DAST_NAMESPACE}" --timeout=60s
+
+echo "Listing PVC contents:"
+oc exec results-fetcher -n "${DAST_NAMESPACE}" -- ls -la /results/ 2>/dev/null || true
+
+oc cp "${DAST_NAMESPACE}/results-fetcher:/results/oobtkube-results.sarif" \
+    "${RESULTS_DIR}/oobtkube-results.sarif" 2>/dev/null && \
+    ok "SARIF retrieved: ${RESULTS_DIR}/oobtkube-results.sarif" || \
+    fail "No SARIF file found on PVC"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 10: Trivy scan
+# ─────────────────────────────────────────────────────────────────────────────
+header "Phase 10: Trivy misconfiguration scan"
+if command -v trivy &>/dev/null; then
+    trivy k8s --report summary --severity HIGH,CRITICAL \
+        --include-namespaces "${KDO_NAMESPACE}" \
+        --format json --output "${RESULTS_DIR}/trivy-results.json" 2>/dev/null && \
+        ok "Trivy results: ${RESULTS_DIR}/trivy-results.json" || \
+        fail "Trivy scan failed"
+else
+    echo "Trivy not installed locally. Running via container on cluster..."
+    cat <<TRIVYEOF | oc apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: trivy-scan
+  namespace: ${DAST_NAMESPACE}
+spec:
+  serviceAccountName: privileged-sa
+  containers:
+    - name: trivy
+      image: quay.io/redhatproductsecurity/rapidast:latest
+      command: ["/bin/bash", "-c"]
+      args:
+        - |
+          trivy k8s --report summary --severity HIGH,CRITICAL \
+            --include-namespaces ${KDO_NAMESPACE} --format table 2>&1
+          exit 0
+  restartPolicy: Never
+TRIVYEOF
+    oc wait --for=condition=Ready pod/trivy-scan -n "${DAST_NAMESPACE}" --timeout=60s 2>/dev/null || true
+    oc wait --for=jsonpath='{.status.phase}'=Succeeded pod/trivy-scan \
+        -n "${DAST_NAMESPACE}" --timeout=120s 2>/dev/null || true
+    echo "--- Trivy output ---"
+    oc logs trivy-scan -n "${DAST_NAMESPACE}" 2>/dev/null && \
+        ok "Trivy scan complete" || \
+        fail "Trivy scan failed (non-critical, oobtkube results still valid)"
+    echo "--- End Trivy ---"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 11: Display results
+# ─────────────────────────────────────────────────────────────────────────────
+header "Phase 11: Results Summary"
+echo ""
+echo "Results directory: ${RESULTS_DIR}"
+ls -la "${RESULTS_DIR}/" 2>/dev/null
+echo ""
+
+if [ -s "${RESULTS_DIR}/oobtkube-results.sarif" ]; then
+    TOTAL=$(jq '[.runs[0].results[]?] | length' "${RESULTS_DIR}/oobtkube-results.sarif" 2>/dev/null || echo "?")
+    CRITICAL=$(jq '[.runs[0].results[]? | select(.level == "error")] | length' "${RESULTS_DIR}/oobtkube-results.sarif" 2>/dev/null || echo "?")
+    HIGH=$(jq '[.runs[0].results[]? | select(.level == "warning")] | length' "${RESULTS_DIR}/oobtkube-results.sarif" 2>/dev/null || echo "?")
+    MEDIUM=$(jq '[.runs[0].results[]? | select(.level == "note")] | length' "${RESULTS_DIR}/oobtkube-results.sarif" 2>/dev/null || echo "?")
+
+    echo "┌─────────────────────────────────────┐"
+    echo "│  oobtkube DAST Results               │"
+    echo "├─────────────────────────────────────┤"
+    echo "│  Total findings:  ${TOTAL}"
+    echo "│  Critical:        ${CRITICAL}"
+    echo "│  High:            ${HIGH}"
+    echo "│  Medium:          ${MEDIUM}"
+    echo "└─────────────────────────────────────┘"
+    ok "DAST test PASSED - SARIF produced successfully"
+else
+    echo "┌─────────────────────────────────────┐"
+    echo "│  No SARIF file produced.             │"
+    echo "│  Check Job logs for errors.          │"
+    echo "└─────────────────────────────────────┘"
+    fail "DAST test - no SARIF output (check logs above)"
+fi
+
+echo ""
+echo "Full Job logs: oc logs job/rapidast-kdo-oobtkube -n ${DAST_NAMESPACE}"
+echo "SARIF file:    ${RESULTS_DIR}/oobtkube-results.sarif"
+echo ""
+ok "CRC DAST test complete!"


### PR DESCRIPTION
## Summary

- Adds a Konflux DAST pipeline for Kube Descheduler Operator (OCP 4.21)
- Runs **RapiDAST oobtkube** (blind command injection testing via enriched CR) and **Trivy** misconfiguration scanning on an ephemeral EaaS cluster
- Config files are externalized under `configs/` for maintainability: RapiDAST config, enriched KubeDescheduler CR, and RapiDAST Job spec

## Files

| File | Purpose |
|------|---------|
| `pipelines/kube-descheduler-operator-dast-pipeline-4-21.yaml` | Tekton Pipeline: parse-metadata, EaaS provisioning, operator install, DAST orchestration, post-process |
| `configs/rapidastconfig.yaml` | RapiDAST `generic_oobtkube` scanner config (uses `python3.12`, `POD_IP` via downward API) |
| `configs/kdo-cr.yaml` | Enriched KubeDescheduler CR with all spec fields populated for maximum oobtkube injection coverage |
| `configs/rapidast-job.yaml` | RapiDAST Job spec (runs on ephemeral cluster, writes SARIF to PVC, uploads to GCS) |

## Test plan

- [x] Validated locally on CRC (OCP 4.21.8) with real Quay bundle image (`v5.3.3`)
- [x] oobtkube successfully tested all 23 CR leaf keys, 0 command injection findings
- [x] Trivy scanned KDO namespace, 0 HIGH/CRITICAL misconfigurations
- [x] SARIF output produced and retrievable from PVC
- [ ] Requires `IntegrationTestScenario` in `konflux-release-data` (optional, non-blocking)
- [ ] Requires GCS secret `rapidast-sa-kdo-key` in `kdo-workloads-tenant` namespace