### PR TITLE
NO-JIRA: Add required-scc annotations,terminationMessagePolicy to pods,OTE Test Binary Packaging

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,10 +1,12 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-kube-descheduler-operator
 COPY . .
-RUN make build --warn-undefined-variables
+RUN make build --warn-undefined-variables \
+    && gzip cluster-kube-descheduler-operator-tests-ext
 
 FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-descheduler-operator/cluster-kube-descheduler-operator /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/cluster-kube-descheduler-operator/cluster-kube-descheduler-operator-tests-ext.gz /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-descheduler-operator/soft-tainter /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-descheduler-operator/manifests /manifests
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-descheduler-operator/metadata /metadata

--- a/bindata/assets/kube-descheduler/deployment.yaml
+++ b/bindata/assets/kube-descheduler/deployment.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: openshift-descheduler
+        openshift.io/required-scc: restricted-v2
       labels:
         app: "descheduler"
     spec:
@@ -38,6 +39,7 @@ spec:
             capabilities:
               drop: ["ALL"]
           image: ${OPERAND_IMAGE}
+          terminationMessagePolicy: FallbackToLogsOnError
           resources:
             requests:
               cpu: "100m"

--- a/bindata/assets/kube-descheduler/softtainterdeployment.yaml
+++ b/bindata/assets/kube-descheduler/softtainterdeployment.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: openshift-softtainer
+        openshift.io/required-scc: restricted-v2
       labels:
         app: "softtainer"
     spec:
@@ -38,6 +39,7 @@ spec:
             capabilities:
               drop: ["ALL"]
           image: ${SOFTTAINTER_IMAGE}
+          terminationMessagePolicy: FallbackToLogsOnError
           livenessProbe:
             failureThreshold: 1
             httpGet:

--- a/deploy/05_deployment.yaml
+++ b/deploy/05_deployment.yaml
@@ -10,6 +10,8 @@ spec:
       name: descheduler-operator
   template:
     metadata:
+      annotations:
+        openshift.io/required-scc: restricted-v2
       labels:
         name: descheduler-operator
     spec:
@@ -21,6 +23,7 @@ spec:
             capabilities:
               drop: ["ALL"]
           image: quay.io/openshift/origin-cluster-kube-descheduler-operator:latest
+          terminationMessagePolicy: FallbackToLogsOnError
           ports:
           - containerPort: 60000
             name: metrics

--- a/manifests/cluster-kube-descheduler-operator.clusterserviceversion.yaml
+++ b/manifests/cluster-kube-descheduler-operator.clusterserviceversion.yaml
@@ -366,6 +366,8 @@ spec:
                 name: descheduler-operator
             template:
               metadata:
+                annotations:
+                  openshift.io/required-scc: restricted-v2
                 labels:
                   name: descheduler-operator
               spec:
@@ -381,6 +383,7 @@ spec:
                       capabilities:
                         drop: ["ALL"]
                     image: registry-proxy.engineering.redhat.com/rh-osbs/kube-descheduler-operator-rhel-9:latest
+                    terminationMessagePolicy: FallbackToLogsOnError
                     resources:
                       requests:
                         memory: 50Mi

--- a/pkg/operator/target_config_reconciler_test.go
+++ b/pkg/operator/target_config_reconciler_test.go
@@ -737,8 +737,9 @@ func TestManageDeployment(t *testing.T) {
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
 								{
-									Name:  "openshift-descheduler",
-									Image: "",
+									Name:                     "openshift-descheduler",
+									Image:                    "",
+									TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 									SecurityContext: &corev1.SecurityContext{
 										AllowPrivilegeEscalation: utilptr.To[bool](false),
 										ReadOnlyRootFilesystem:   utilptr.To[bool](true),
@@ -909,7 +910,7 @@ func TestManageSoftTainterDeployment(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "softtainter",
 			Namespace:       "openshift-kube-descheduler-operator",
-			Annotations:     map[string]string{"operator.openshift.io/spec-hash": "6b9c733e7ea834308aa02b01074bf5d2e66e551c5e178f2d21a13c50ed152256"},
+			Annotations:     map[string]string{"operator.openshift.io/spec-hash": "ef97d3d0f3b5175d75facaefb8102ae00469a9d38676a3b6b4a96ef67b52b1b5"},
 			Labels:          map[string]string{"app": "softtainer"},
 			OwnerReferences: []metav1.OwnerReference{{APIVersion: "operator.openshift.io/v1", Kind: "KubeDescheduler", Name: "cluster"}},
 		},
@@ -922,8 +923,11 @@ func TestManageSoftTainterDeployment(t *testing.T) {
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      map[string]string{"app": "softtainer"},
-					Annotations: map[string]string{"kubectl.kubernetes.io/default-container": "openshift-softtainer"},
+					Labels: map[string]string{"app": "softtainer"},
+					Annotations: map[string]string{
+						"kubectl.kubernetes.io/default-container": "openshift-softtainer",
+						"openshift.io/required-scc":               "restricted-v2",
+					},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -934,7 +938,8 @@ func TestManageSoftTainterDeployment(t *testing.T) {
 								"--policy-config-file=/policy-dir/policy.yaml",
 								"-v=2",
 							},
-							Image: "RELATED_IMAGE_SOFTTAINTER_IMAGE",
+							Image:                    "RELATED_IMAGE_SOFTTAINTER_IMAGE",
+							TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 							LivenessProbe: &corev1.Probe{
 								ProbeHandler:        corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/livez", Port: intstr.FromInt32(6060), Scheme: corev1.URISchemeHTTP}},
 								InitialDelaySeconds: 30,

--- a/test/e2e/bindata/assets/05_deployment.yaml
+++ b/test/e2e/bindata/assets/05_deployment.yaml
@@ -12,6 +12,8 @@ spec:
       name: descheduler-operator
   template:
     metadata:
+      annotations:
+        openshift.io/required-scc: restricted-v2
       labels:
         name: descheduler-operator
     spec:
@@ -27,6 +29,7 @@ spec:
             capabilities:
               drop: ["ALL"]
           image: # set in e2e
+          terminationMessagePolicy: FallbackToLogsOnError
           resources:
             requests:
               memory: 50Mi


### PR DESCRIPTION
Hi Team, 

PTAL on the PR. 

Fix:  
1. Security Compliance: Required SCC Annotations: `openshift.io/required-scc: restricted-v2` annotations to all pod templates to comply with OpenShift security requirements.
2. Enhanced Error Diagnostics: Added `terminationMessagePolicy: FallbackToLogsOnError` to operator and operand containers to improve debugging when pods fail.
3. OTE Test Binary Packaging: Fixed `Dockerfile.rhel7` to include the OTE test binary (`cluster-kube-descheduler-operator-tests-ext.gz`)