### PR TITLE
Fix protected namespaces not refreshing after operator start

### DIFF
--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -93,7 +93,6 @@ type TargetConfigReconciler struct {
 	dynamicClient            dynamic.Interface
 	eventRecorder            events.Recorder
 	queue                    workqueue.RateLimitingInterface
-	protectedNamespaces      []string
 	configSchedulerLister    configlistersv1.SchedulerLister
 	routeRouteLister         routelistersv1.RouteLister
 	namespaceLister          corev1listers.NamespaceLister
@@ -116,19 +115,6 @@ func NewTargetConfigReconciler(
 	coreInformers coreinformers.SharedInformerFactory,
 	eventRecorder events.Recorder,
 ) *TargetConfigReconciler {
-	// make sure our list of excluded system namespaces is up to date
-	allNamespaces, err := kubeClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		klog.ErrorS(err, "error listing namespaces")
-		return nil
-	}
-	protectedNamespaces := []string{"kube-system", "hypershift", "openshift"}
-	for _, ns := range allNamespaces.Items {
-		if strings.HasPrefix(ns.Name, "openshift-") {
-			protectedNamespaces = append(protectedNamespaces, ns.Name)
-		}
-	}
-
 	c := &TargetConfigReconciler{
 		ctx:                      ctx,
 		operatorClient:           operatorConfigClient,
@@ -137,7 +123,6 @@ func NewTargetConfigReconciler(
 		dynamicClient:            dynamicClient,
 		eventRecorder:            eventRecorder,
 		queue:                    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "TargetConfigReconciler"),
-		protectedNamespaces:      protectedNamespaces,
 		deschedulerImagePullSpec: deschedulerImagePullSpec,
 		softtainterImagePullSpec: softTainterImagePullSpec,
 		configSchedulerLister:    configInformer.Config().V1().Schedulers().Lister(),
@@ -154,6 +139,21 @@ func NewTargetConfigReconciler(
 	coreInformers.Core().V1().Nodes().Informer().AddEventHandler(c.eventHandler())
 	coreInformers.Core().V1().Namespaces().Informer().AddEventHandler(c.eventHandler())
 	return c
+}
+
+func (c *TargetConfigReconciler) getProtectedNamespaces() ([]string, error) {
+	allNamespaces, err := c.namespaceLister.List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("failed to list namespaces: %w", err)
+	}
+	protectedNamespaces := []string{"kube-system", "hypershift", "openshift"}
+	for _, ns := range allNamespaces {
+		if strings.HasPrefix(ns.Name, "openshift-") {
+			protectedNamespaces = append(protectedNamespaces, ns.Name)
+		}
+	}
+	slices.Sort(protectedNamespaces)
+	return protectedNamespaces, nil
 }
 
 func (c TargetConfigReconciler) scaleDownDeployment(scaleDownError error) error {
@@ -1316,8 +1316,12 @@ func (c *TargetConfigReconciler) manageConfigMap(descheduler *deschedulerv1.Kube
 	}
 
 	// override the included/excluded namespace
-	excludedNamespaces := c.protectedNamespaces
-	protectedNamespacesSet := sets.NewString(c.protectedNamespaces...)
+	protectedNamespaces, err := c.getProtectedNamespaces()
+	if err != nil {
+		return nil, false, err
+	}
+	excludedNamespaces := protectedNamespaces
+	protectedNamespacesSet := sets.NewString(protectedNamespaces...)
 	includedNamespaces := []string{}
 	if descheduler.Spec.ProfileCustomizations != nil {
 		if len(descheduler.Spec.ProfileCustomizations.Namespaces.Excluded) > 0 && len(descheduler.Spec.ProfileCustomizations.Namespaces.Included) > 0 {
@@ -1326,7 +1330,7 @@ func (c *TargetConfigReconciler) manageConfigMap(descheduler *deschedulerv1.Kube
 		if len(descheduler.Spec.ProfileCustomizations.Namespaces.Included) > 0 {
 			for _, ns := range descheduler.Spec.ProfileCustomizations.Namespaces.Included {
 				if protectedNamespacesSet.Has(ns) {
-					return nil, false, fmt.Errorf("Protected namespace %v included. It is forbidden to include any of the protected namespaces from %v", ns, c.protectedNamespaces)
+					return nil, false, fmt.Errorf("Protected namespace %v included. It is forbidden to include any of the protected namespaces from %v", ns, protectedNamespaces)
 				}
 				includedNamespaces = append(includedNamespaces, ns)
 			}
@@ -1402,11 +1406,11 @@ func (c *TargetConfigReconciler) manageConfigMap(descheduler *deschedulerv1.Kube
 		case deschedulerv1.SoftTopologyAndDuplicates:
 			profile, err = softTopologyAndDuplicatesProfile(descheduler.Spec.ProfileCustomizations, includedNamespaces, excludedNamespaces, ignorePVCPods, evictLocalStoragePods)
 		case deschedulerv1.LifecycleAndUtilization:
-			profile, err = lifecycleAndUtilizationProfile(descheduler.Spec.ProfileCustomizations, includedNamespaces, excludedNamespaces, c.protectedNamespaces, ignorePVCPods, evictLocalStoragePods)
+			profile, err = lifecycleAndUtilizationProfile(descheduler.Spec.ProfileCustomizations, includedNamespaces, excludedNamespaces, protectedNamespaces, ignorePVCPods, evictLocalStoragePods)
 		case deschedulerv1.EvictPodsWithLocalStorage, deschedulerv1.EvictPodsWithPVC:
 			continue
 		case deschedulerv1.DevPreviewLongLifecycle, deschedulerv1.LongLifecycle:
-			profile, err = longLifecycleProfile(descheduler.Spec.ProfileCustomizations, includedNamespaces, excludedNamespaces, c.protectedNamespaces, ignorePVCPods, evictLocalStoragePods)
+			profile, err = longLifecycleProfile(descheduler.Spec.ProfileCustomizations, includedNamespaces, excludedNamespaces, protectedNamespaces, ignorePVCPods, evictLocalStoragePods)
 		case deschedulerv1.CompactAndScale:
 			profile, err = compactAndScaleProfile(descheduler.Spec.ProfileCustomizations, includedNamespaces, excludedNamespaces, ignorePVCPods, evictLocalStoragePods)
 		case deschedulerv1.KubeVirtRelieveAndMigrate, deschedulerv1.DevKubeVirtRelieveAndMigrate:
@@ -1426,7 +1430,7 @@ func (c *TargetConfigReconciler) manageConfigMap(descheduler *deschedulerv1.Kube
 			}
 			kubeVirtShedulable := kubeVirtShedulableLabelSelector
 			policy.NodeSelector = &kubeVirtShedulable
-			profile, err = kubeVirtRelieveAndMigrateProfile(descheduler.Spec.ProfileCustomizations, includedNamespaces, excludedNamespaces, c.protectedNamespaces)
+			profile, err = kubeVirtRelieveAndMigrateProfile(descheduler.Spec.ProfileCustomizations, includedNamespaces, excludedNamespaces, protectedNamespaces)
 		default:
 			err = fmt.Errorf("Profile %q not recognized", profileName)
 		}

--- a/pkg/operator/target_config_reconciler_test.go
+++ b/pkg/operator/target_config_reconciler_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
@@ -715,6 +716,78 @@ func TestManageConfigMap(t *testing.T) {
 				t.Errorf("manageConfigMap diff \n\n %+v", cmp.Diff(tt.want.Data, got.Data))
 			}
 		})
+	}
+}
+
+func TestGetProtectedNamespacesRefresh(t *testing.T) {
+	ctx, cancelFunc := context.WithCancel(context.TODO())
+	defer cancelFunc()
+
+	initialObjects := []runtime.Object{
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "openshift-kube-scheduler",
+			},
+		},
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "kube-system",
+			},
+		},
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   operatorclient.OperatorNamespace,
+				Labels: map[string]string{operatorclient.OpenshiftClusterMonitoringLabelKey: operatorclient.OpenshiftClusterMonitoringLabelValue},
+			},
+		},
+	}
+
+	fakeKubeClient := fake.NewSimpleClientset(initialObjects...)
+	coreInformers := coreinformers.NewSharedInformerFactory(fakeKubeClient, 10*time.Minute)
+
+	reconciler := &TargetConfigReconciler{
+		namespaceLister: coreInformers.Core().V1().Namespaces().Lister(),
+	}
+
+	coreInformers.Start(ctx.Done())
+	coreInformers.WaitForCacheSync(ctx.Done())
+
+	// Before creating the new namespace, openshift-cnv should not be protected
+	before, err := reconciler.getProtectedNamespaces()
+	if err != nil {
+		t.Fatalf("Failed to get protected namespaces: %v", err)
+	}
+	for _, ns := range before {
+		if ns == "openshift-cnv" {
+			t.Fatal("openshift-cnv should not be in protected namespaces before creation")
+		}
+	}
+
+	// Simulate late namespace creation (e.g. CNV installed after descheduler)
+	_, err = fakeKubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "openshift-cnv",
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create namespace: %v", err)
+	}
+
+	// Wait for informer to pick up the new namespace
+	err = wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+		nsList, err := reconciler.getProtectedNamespaces()
+		if err != nil {
+			return false, err
+		}
+		for _, ns := range nsList {
+			if ns == "openshift-cnv" {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("openshift-cnv was not picked up by getProtectedNamespaces after creation: %v", err)
 	}
 }
 

--- a/pkg/operator/testdata/assets/highNodeUtilization.yaml
+++ b/pkg/operator/testdata/assets/highNodeUtilization.yaml
@@ -6,8 +6,8 @@ profiles:
   - args:
       evictableNamespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler

--- a/pkg/operator/testdata/assets/highNodeUtilizationMinimal.yaml
+++ b/pkg/operator/testdata/assets/highNodeUtilizationMinimal.yaml
@@ -6,8 +6,8 @@ profiles:
   - args:
       evictableNamespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler

--- a/pkg/operator/testdata/assets/highNodeUtilizationModerate.yaml
+++ b/pkg/operator/testdata/assets/highNodeUtilizationModerate.yaml
@@ -6,8 +6,8 @@ profiles:
   - args:
       evictableNamespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler

--- a/pkg/operator/testdata/assets/lifecycleAndUtilizationEvictPvcPodsConfig.yaml
+++ b/pkg/operator/testdata/assets/lifecycleAndUtilizationEvictPvcPodsConfig.yaml
@@ -7,8 +7,8 @@ profiles:
       maxPodLifeTimeSeconds: 86400
       namespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
@@ -17,8 +17,8 @@ profiles:
       includingInitContainers: true
       namespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
@@ -27,8 +27,8 @@ profiles:
   - args:
       evictableNamespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler

--- a/pkg/operator/testdata/assets/lifecycleAndUtilizationPodLifeTimeCustomizationConfig.yaml
+++ b/pkg/operator/testdata/assets/lifecycleAndUtilizationPodLifeTimeCustomizationConfig.yaml
@@ -7,8 +7,8 @@ profiles:
       maxPodLifeTimeSeconds: 300
       namespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
@@ -17,8 +17,8 @@ profiles:
       includingInitContainers: true
       namespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
@@ -27,8 +27,8 @@ profiles:
   - args:
       evictableNamespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler

--- a/pkg/operator/testdata/assets/lifecycleAndUtilizationPodLifeTimeWithThresholdPriorityClassNameConfig.yaml
+++ b/pkg/operator/testdata/assets/lifecycleAndUtilizationPodLifeTimeWithThresholdPriorityClassNameConfig.yaml
@@ -7,8 +7,8 @@ profiles:
       maxPodLifeTimeSeconds: 86400
       namespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
@@ -17,8 +17,8 @@ profiles:
       includingInitContainers: true
       namespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
@@ -27,8 +27,8 @@ profiles:
   - args:
       evictableNamespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler

--- a/pkg/operator/testdata/assets/lifecycleAndUtilizationPodLifeTimeWithThresholdPriorityConfig.yaml
+++ b/pkg/operator/testdata/assets/lifecycleAndUtilizationPodLifeTimeWithThresholdPriorityConfig.yaml
@@ -7,8 +7,8 @@ profiles:
       maxPodLifeTimeSeconds: 86400
       namespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
@@ -17,8 +17,8 @@ profiles:
       includingInitContainers: true
       namespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
@@ -27,8 +27,8 @@ profiles:
   - args:
       evictableNamespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler

--- a/pkg/operator/testdata/assets/longLifecycleWithLocalStorage.yaml
+++ b/pkg/operator/testdata/assets/longLifecycleWithLocalStorage.yaml
@@ -7,8 +7,8 @@ profiles:
       includingInitContainers: true
       namespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
@@ -17,8 +17,8 @@ profiles:
   - args:
       evictableNamespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler

--- a/pkg/operator/testdata/assets/longLifecycleWithMetrics.yaml
+++ b/pkg/operator/testdata/assets/longLifecycleWithMetrics.yaml
@@ -11,8 +11,8 @@ profiles:
       includingInitContainers: true
       namespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
@@ -21,8 +21,8 @@ profiles:
   - args:
       evictableNamespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler

--- a/pkg/operator/testdata/assets/longLifecycleWithNamespaces.yaml
+++ b/pkg/operator/testdata/assets/longLifecycleWithNamespaces.yaml
@@ -13,8 +13,8 @@ profiles:
   - args:
       evictableNamespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler

--- a/pkg/operator/testdata/assets/lowNodeUtilizationEvictionLimits.yaml
+++ b/pkg/operator/testdata/assets/lowNodeUtilizationEvictionLimits.yaml
@@ -9,8 +9,8 @@ profiles:
       maxPodLifeTimeSeconds: 86400
       namespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
@@ -19,8 +19,8 @@ profiles:
       includingInitContainers: true
       namespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
@@ -29,8 +29,8 @@ profiles:
   - args:
       evictableNamespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler

--- a/pkg/operator/testdata/assets/lowNodeUtilizationHighConfig.yaml
+++ b/pkg/operator/testdata/assets/lowNodeUtilizationHighConfig.yaml
@@ -7,8 +7,8 @@ profiles:
       maxPodLifeTimeSeconds: 86400
       namespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
@@ -17,8 +17,8 @@ profiles:
       includingInitContainers: true
       namespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
@@ -27,8 +27,8 @@ profiles:
   - args:
       evictableNamespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler

--- a/pkg/operator/testdata/assets/lowNodeUtilizationIncludedNamespace.yaml
+++ b/pkg/operator/testdata/assets/lowNodeUtilizationIncludedNamespace.yaml
@@ -19,8 +19,8 @@ profiles:
   - args:
       evictableNamespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler

--- a/pkg/operator/testdata/assets/lowNodeUtilizationLowConfig.yaml
+++ b/pkg/operator/testdata/assets/lowNodeUtilizationLowConfig.yaml
@@ -7,8 +7,8 @@ profiles:
       maxPodLifeTimeSeconds: 86400
       namespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
@@ -17,8 +17,8 @@ profiles:
       includingInitContainers: true
       namespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
@@ -27,8 +27,8 @@ profiles:
   - args:
       evictableNamespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler

--- a/pkg/operator/testdata/assets/lowNodeUtilizationMediumConfig.yaml
+++ b/pkg/operator/testdata/assets/lowNodeUtilizationMediumConfig.yaml
@@ -7,8 +7,8 @@ profiles:
       maxPodLifeTimeSeconds: 86400
       namespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
@@ -17,8 +17,8 @@ profiles:
       includingInitContainers: true
       namespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
@@ -27,8 +27,8 @@ profiles:
   - args:
       evictableNamespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler

--- a/pkg/operator/testdata/assets/relieveAndMigrateDefaults.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateDefaults.yaml
@@ -13,8 +13,8 @@ profiles:
   - args:
       evictableNamespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler

--- a/pkg/operator/testdata/assets/relieveAndMigrateDeviationLowWithCombinedMetrics.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateDeviationLowWithCombinedMetrics.yaml
@@ -13,8 +13,8 @@ profiles:
   - args:
       evictableNamespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler

--- a/pkg/operator/testdata/assets/relieveAndMigrateDynamicThresholdsHigh.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateDynamicThresholdsHigh.yaml
@@ -13,8 +13,8 @@ profiles:
   - args:
       evictableNamespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler

--- a/pkg/operator/testdata/assets/relieveAndMigrateDynamicThresholdsLow.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateDynamicThresholdsLow.yaml
@@ -13,8 +13,8 @@ profiles:
   - args:
       evictableNamespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler

--- a/pkg/operator/testdata/assets/relieveAndMigrateDynamicThresholdsMedium.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateDynamicThresholdsMedium.yaml
@@ -13,8 +13,8 @@ profiles:
   - args:
       evictableNamespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler

--- a/pkg/operator/testdata/assets/relieveAndMigrateEvictionLimits.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateEvictionLimits.yaml
@@ -13,8 +13,8 @@ profiles:
   - args:
       evictableNamespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler

--- a/pkg/operator/testdata/assets/relieveAndMigrateHighConfig.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateHighConfig.yaml
@@ -13,8 +13,8 @@ profiles:
   - args:
       evictableNamespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler

--- a/pkg/operator/testdata/assets/relieveAndMigrateIncludedNamespace.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateIncludedNamespace.yaml
@@ -13,8 +13,8 @@ profiles:
   - args:
       evictableNamespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler

--- a/pkg/operator/testdata/assets/relieveAndMigrateLowConfig.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateLowConfig.yaml
@@ -13,8 +13,8 @@ profiles:
   - args:
       evictableNamespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler

--- a/pkg/operator/testdata/assets/relieveAndMigrateMediumConfig.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateMediumConfig.yaml
@@ -13,8 +13,8 @@ profiles:
   - args:
       evictableNamespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler

--- a/pkg/operator/testdata/assets/relieveAndMigrateMigrationCooldown.yaml
+++ b/pkg/operator/testdata/assets/relieveAndMigrateMigrationCooldown.yaml
@@ -13,8 +13,8 @@ profiles:
   - args:
       evictableNamespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler

--- a/pkg/operator/testdata/assets/softTopologyAndDuplicates.yaml
+++ b/pkg/operator/testdata/assets/softTopologyAndDuplicates.yaml
@@ -9,8 +9,8 @@ profiles:
       - ScheduleAnyway
       namespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
@@ -18,8 +18,8 @@ profiles:
   - args:
       namespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler

--- a/pkg/operator/testdata/assets/topologyAndDuplicates.yaml
+++ b/pkg/operator/testdata/assets/topologyAndDuplicates.yaml
@@ -8,8 +8,8 @@ profiles:
       - DoNotSchedule
       namespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler
@@ -17,8 +17,8 @@ profiles:
   - args:
       namespaces:
         exclude:
-        - kube-system
         - hypershift
+        - kube-system
         - openshift
         - openshift-kube-descheduler-operator
         - openshift-kube-scheduler


### PR DESCRIPTION
The list of protected namespaces (`openshift-*`) was built once in `NewTargetConfigReconciler` via a direct API call and cached in the struct field for the lifetime of the process. Namespaces created after the operator started (e.g. `openshift-cnv` from a late CNV install) were never added to the exclusion list, leaving them unprotected from descheduling until the operator pod restarted.

Replace the cached `protectedNamespaces` field with a `getProtectedNamespaces()` method that queries the namespace informer cache on each reconciliation. The namespace informer was already present and synced, so the performance impact is negligible: only the derived list of protected namespaces was unnecessarily cached. The list is now sorted for deterministic output.

Add `TestGetProtectedNamespacesRefresh` to explicitly verify that namespaces created after initialization are picked up.

Fixes: [CNV-89284](https://redhat.atlassian.net/browse/CNV-89284)