### PR TITLE
CNTRLPLANE-3864: Add NetworkPolicy RBAC to descheduler operator CSV

### DIFF
--- a/deploy/02_clusterrole.yaml
+++ b/deploy/02_clusterrole.yaml
@@ -254,3 +254,15 @@ rules:
     verbs:
       - get
       - list
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/manifests/cluster-kube-descheduler-operator.clusterserviceversion.yaml
+++ b/manifests/cluster-kube-descheduler-operator.clusterserviceversion.yaml
@@ -402,6 +402,18 @@ spec:
               verbs:
                 - get
                 - list
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
       permissions:
         - serviceAccountName: openshift-descheduler
           rules:

--- a/test/e2e/bindata/assets/03_clusterrole.yaml
+++ b/test/e2e/bindata/assets/03_clusterrole.yaml
@@ -254,3 +254,15 @@ rules:
     verbs:
       - get
       - list
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch


### PR DESCRIPTION
Hi Team,

PTAL. 

PR about:  Add networking.k8s.io/networkpolicies permissions (create, delete, update) to the operator's clusterPermissions in the CSV. This satisfies the Conforma policy olm.required_network_policy_rbac_for_operands for OCP 5.0 compliance.

// Without this PR fix we receive warning as, 
```
[Warning] olm.required_network_policy_rbac_for_operands
       ImageRef: registry.redhat.io/kube-descheduler-operator/kube-descheduler-operator-bundle@sha256:c825960061a77552cbda6908475604447880ad030332f12c89c6e1f98827cf5a
       Reason: Operator "cluster-kube-descheduler-operator" version "5.4.0" is missing required NetworkPolicy RBAC
       (networking.k8s.io/networkpolicies with create, delete, and update/patch)
       Title: NetworkPolicy RBAC present in OLM bundle
       Description: Operators are required to manage the network policies of their operands. This rule verifies that operator bundles
       request sufficient RBAC permissions to manage NetworkPolicy lifecycle (create, delete, and update/patch) for
       networking.k8s.io/networkpolicies in their ClusterServiceVersion. Bundles whose operator name and major.minor version are listed
       in the `operator_network_policy_rbac_exceptions` rule data key are exempt from this requirement.
       Solution: Add a rule granting create, delete, and update/patch on networking.k8s.io/networkpolicies to the ClusterServiceVersion
       clusterPermissions or permissions, or add the operator name and its major.minor version to the
       operator_network_policy_rbac_exceptions rule data key
```

// With PR fix we did not observe network policy warning
```
ec validate image \
    --image quay.io/redhat-user-workloads/kdo-workloads-tenant/kube-descheduler-operator-bundle-main:on-pr-3ef1b865e13eb86af2c2215579cac92aa885f7e2 \
    --policy '{"sources":[{"policy":["oci::quay.io/enterprise-contract/ec-release-policy:latest"]}]}' \
    --ignore-rekor \
    --skip-image-sig-check \
    --skip-att-sig-check \
    --certificate-identity-regexp '.*' \
    --certificate-oidc-issuer-regexp '.*' \
    --output text \
    --strict false \
    --info
Violations: 28, Warnings: 15, Successes: 145
Component: Unnamed
ImageRef: quay.io/redhat-user-workloads/kdo-workloads-tenant/kube-descheduler-operator-bundle-main@sha256:c18cecd7b9008b7ef5cbdce50594beb86aee3004e1c9af0b93035eeb6975f43c

....
....
....
› [Warning] test.no_test_warnings
  ImageRef: quay.io/redhat-user-workloads/kdo-workloads-tenant/kube-descheduler-operator-bundle-main@sha256:c18cecd7b9008b7ef5cbdce50594beb86aee3004e1c9af0b93035eeb6975f43c
  Reason: The Task "deprecated-image-check" from the build Pipeline reports a test contains warnings
  Term: deprecated-image-check
  Title: No tests produced warnings
  Description: Produce a warning if any tests have their result set to "WARNING". The result type is configurable by the
  "warned_tests_results" key in the rule data.
  Solution: There is a task with result 'TEST_OUTPUT' that returned a result of 'WARNING'. You can find which test resulted in
  'WARNING' by examining the 'result' key in the 'TEST_OUTPUT'. More information about the test should be available in the logs
  for the build Pipeline.
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Expanded operator permissions to manage network policies.
  * Added support for full lifecycle operations (create, update, delete) and standard read/watch access for network policy resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->