### PR TITLE
No-JIRA: fix Olm installation issue

### DIFF
--- a/test/e2e/descheduler_utils.go
+++ b/test/e2e/descheduler_utils.go
@@ -718,6 +718,14 @@ func packagemanifestKDO(ctx context.Context, dynamicClient dynamic.Interface, pa
 		return nil, fmt.Errorf("failed to convert Subscription from unstructured: %w", err)
 	}
 
+	// The unstructured Subscription uses "package" for the package name field,
+	// but the typed Subscription struct maps Package to JSON tag "name".
+	// FromUnstructured looks for "name" in spec and finds nothing, leaving
+	// Spec.Package empty. Set it explicitly from the known packageName.
+	if sub.Spec.Package == "" {
+		sub.Spec.Package = packageName
+	}
+
 	klog.Infof("Found package manifest: channel=%s, source=%s, startingCSV=%s",
 		sub.Spec.Channel, sub.Spec.CatalogSource, sub.Spec.StartingCSV)
 

--- a/test/e2e/descheduler_verification.go
+++ b/test/e2e/descheduler_verification.go
@@ -73,36 +73,44 @@ var _ = g.Describe("[OTP][Operator][Serial] Descheduler Operator Functionality",
 	})
 
 	g.AfterAll(func() {
-		if cancelFnc != nil {
-			cancelFnc()
-		}
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cleanupCancel()
 
 		if isOperatorOLMInstallationEnabled() {
-			// Cleanup OLM resources
 			g.By("Cleaning up operator installation")
+
 			og := &operatorsv1.OperatorGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "descheduler-og",
 					Namespace: operatorclient.OperatorNamespace,
 				},
 			}
-			sub, _ := packagemanifestKDO(ctx, dynamicClient, "cluster-kube-descheduler-operator", operatorclient.OperatorNamespace, []string{"redhat-operators"})
+			sub, err := packagemanifestKDO(cleanupCtx, dynamicClient, "cluster-kube-descheduler-operator", operatorclient.OperatorNamespace, []string{"redhat-operators"})
+			if err != nil {
+				klog.Warningf("Failed to get packagemanifest for cleanup: %v", err)
+			}
 
-			deleteKubeDescheduler(ctx, deschClient, operatorclient.OperatorNamespace, operatorclient.OperatorConfigName)
-			deleteSubscription(ctx, dynamicClient, sub)
-			deleteOperatorGroup(ctx, dynamicClient, og)
+			if err := deleteKubeDescheduler(cleanupCtx, deschClient, operatorclient.OperatorNamespace, operatorclient.OperatorConfigName); err != nil {
+				klog.Warningf("Failed to delete KubeDescheduler: %v", err)
+			}
+			if sub != nil {
+				if err := deleteSubscription(cleanupCtx, dynamicClient, sub); err != nil {
+					klog.Warningf("Failed to delete Subscription: %v", err)
+				}
+			}
+			if err := deleteOperatorGroup(cleanupCtx, dynamicClient, og); err != nil {
+				klog.Warningf("Failed to delete OperatorGroup: %v", err)
+			}
 		}
 
-		// Delete the namespace
 		g.By("Deleting operator namespace")
-		err := kubeClient.CoreV1().Namespaces().Delete(ctx, operatorclient.OperatorNamespace, metav1.DeleteOptions{})
+		err := kubeClient.CoreV1().Namespaces().Delete(cleanupCtx, operatorclient.OperatorNamespace, metav1.DeleteOptions{})
 		if err != nil {
 			klog.Warningf("Failed to delete namespace %s: %v", operatorclient.OperatorNamespace, err)
 		}
 
-		// Wait for namespace to be fully deleted before completing AfterAll
 		g.By("Ensuring namespace is fully deleted")
-		err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+		err = wait.PollUntilContextTimeout(cleanupCtx, 5*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
 			_, err := kubeClient.CoreV1().Namespaces().Get(ctx, operatorclient.OperatorNamespace, metav1.GetOptions{})
 			if err != nil {
 				if strings.Contains(err.Error(), "not found") {
@@ -117,6 +125,10 @@ var _ = g.Describe("[OTP][Operator][Serial] Descheduler Operator Functionality",
 		})
 		if err != nil {
 			klog.Warningf("Timeout waiting for namespace deletion: %v", err)
+		}
+
+		if cancelFnc != nil {
+			cancelFnc()
 		}
 	})
 


### PR DESCRIPTION
Hi Team,

PTAL on the PR. 

Fix two bugs preventing OLM-based operator installation from working
in e2e tests:

Fixes:
- Set sub.Spec.Package = packageName explicitly after FromUnstructured
- Use a separate cleanupCtx with 5-minute timeout for AfterAll
- Move cancelFnc() to the end of AfterAll
- Add nil check for sub before deleteSubscription

// Execution PASS logs:
```
=== RUN   TestE2E
Running Suite: Cluster Kube Descheduler Operator E2E Suite - /home/ropatil/Downloads/cntrlplane-2154/cluster-kube-descheduler-operator/test/e2e
===============================================================================================================================================
Random Seed: 1787726253

Will run 1 of 20 specs
SI0826 12:07:33.550838   50179 descheduler_utils.go:48] Creating the operator namespace
I0826 12:07:34.450456   50179 descheduler_utils.go:59] Setting up OperatorGroup
I0826 12:07:34.450474   50179 descheduler_utils.go:70] Fetching subscription details from packagemanifest
I0826 12:07:34.450482   50179 descheduler_utils.go:706] Fetching packagemanifest values for cluster-kube-descheduler-operator
I0826 12:07:34.720756   50179 descheduler_utils.go:729] Found package manifest: channel=stable, source=cs-osso, startingCSV=clusterkubedescheduleroperator.v5.4.2
I0826 12:07:34.720772   50179 descheduler_utils.go:76] Creating OperatorGroup
I0826 12:07:34.720776   50179 descheduler_utils.go:144] Creating OperatorGroup descheduler-og in namespace openshift-kube-descheduler-operator
I0826 12:07:35.980169   50179 descheduler_utils.go:162] Successfully created OperatorGroup descheduler-og
I0826 12:07:35.980205   50179 descheduler_utils.go:82] Creating Subscription
I0826 12:07:35.980215   50179 descheduler_utils.go:192] Creating Subscription cluster-kube-descheduler-operator in namespace openshift-kube-descheduler-operator
I0826 12:07:36.287221   50179 descheduler_utils.go:210] Successfully created Subscription cluster-kube-descheduler-operator
I0826 12:07:36.287240   50179 descheduler_utils.go:88] Waiting for descheduler operator deployment
W0826 12:07:36.517518   50179 descheduler_utils.go:451] Failed to get deployment openshift-kube-descheduler-operator/descheduler-operator: deployments.apps "descheduler-operator" not found
W0826 12:07:41.517204   50179 descheduler_utils.go:451] Failed to get deployment openshift-kube-descheduler-operator/descheduler-operator: deployments.apps "descheduler-operator" not found
W0826 12:07:46.516315   50179 descheduler_utils.go:451] Failed to get deployment openshift-kube-descheduler-operator/descheduler-operator: deployments.apps "descheduler-operator" not found
W0826 12:07:52.387308   50179 descheduler_utils.go:451] Failed to get deployment openshift-kube-descheduler-operator/descheduler-operator: deployments.apps "descheduler-operator" not found
W0826 12:07:56.518496   50179 descheduler_utils.go:451] Failed to get deployment openshift-kube-descheduler-operator/descheduler-operator: deployments.apps "descheduler-operator" not found
W0826 12:08:01.519782   50179 descheduler_utils.go:451] Failed to get deployment openshift-kube-descheduler-operator/descheduler-operator: deployments.apps "descheduler-operator" not found
W0826 12:08:06.516859   50179 descheduler_utils.go:451] Failed to get deployment openshift-kube-descheduler-operator/descheduler-operator: deployments.apps "descheduler-operator" not found
I0826 12:08:11.934370   50179 descheduler_utils.go:464] Waiting for deployment openshift-kube-descheduler-operator/descheduler-operator: 0/1 replicas ready
I0826 12:08:16.749039   50179 descheduler_utils.go:460] Deployment openshift-kube-descheduler-operator/descheduler-operator is ready with 1 replicas
I0826 12:08:16.749076   50179 descheduler_utils.go:92] Waiting for CSV to succeed
I0826 12:08:18.002831   50179 descheduler_utils.go:624] Found CSV: clusterkubedescheduleroperator.v5.4.2
I0826 12:08:18.002848   50179 descheduler_utils.go:663] Waiting for CSV openshift-kube-descheduler-operator/clusterkubedescheduleroperator.v5.4.2 to succeed
I0826 12:08:19.626468   50179 descheduler_utils.go:683] CSV clusterkubedescheduleroperator.v5.4.2 current phase: Succeeded
I0826 12:08:19.626486   50179 descheduler_utils.go:700] CSV clusterkubedescheduleroperator.v5.4.2 succeeded
I0826 12:08:19.626492   50179 descheduler_utils.go:112] Descheduler operator successfully installed via OLM, CSV: clusterkubedescheduleroperator.v5.4.2
I0826 12:08:19.626496   50179 descheduler_utils.go:117] Creating KubeDescheduler CR
I0826 12:08:19.909341   50179 descheduler_utils.go:124] Waiting for descheduler operand deployment
I0826 12:08:31.104212   50179 descheduler_utils.go:460] Deployment openshift-kube-descheduler-operator/descheduler is ready with 1 replicas
I0826 12:08:31.104245   50179 descheduler_utils.go:138] Descheduler operand successfully deployed and running
I0826 12:08:32.592267   50179 descheduler_utils.go:624] Found CSV: clusterkubedescheduleroperator.v5.4.2
I0826 12:08:32.592294   50179 descheduler_verification.go:556] Found CSV: clusterkubedescheduleroperator.v5.4.2
I0826 12:08:33.702072   50179 descheduler_utils.go:657] Found 2 related images in CSV clusterkubedescheduleroperator.v5.4.2
I0826 12:08:33.702090   50179 descheduler_verification.go:566] Found relatedImage: descheduler-operand -> registry.redhat.io/kube-descheduler-operator/descheduler-rhel9@sha256:c1fd22486ef42d9fa86f8acfc7fe5f1db60fc8ed5b2829fa2a86c40c31a3f48b
I0826 12:08:33.702094   50179 descheduler_verification.go:566] Found relatedImage: descheduler-operator -> registry.redhat.io/kube-descheduler-operator/kube-descheduler-rhel9-operator@sha256:ea87bfb6c8ae17de1d483eb7da6defcb0f4825c4c6f402fd15743da5285de326
I0826 12:08:33.702100   50179 descheduler_verification.go:578] RelatedImages validation completed successfully - found 2 images
I0826 12:08:33.702150   50179 descheduler_utils.go:706] Fetching packagemanifest values for cluster-kube-descheduler-operator
I0826 12:08:34.418004   50179 descheduler_utils.go:729] Found package manifest: channel=stable, source=cs-osso, startingCSV=clusterkubedescheduleroperator.v5.4.2
I0826 12:08:34.650866   50179 descheduler_utils.go:216] Deleting Subscription cluster-kube-descheduler-operator in namespace openshift-kube-descheduler-operator
I0826 12:08:35.104577   50179 descheduler_utils.go:234] Successfully deleted Subscription cluster-kube-descheduler-operator
I0826 12:08:35.104597   50179 descheduler_utils.go:168] Deleting OperatorGroup descheduler-og in namespace openshift-kube-descheduler-operator
I0826 12:08:35.554106   50179 descheduler_utils.go:186] Successfully deleted OperatorGroup descheduler-og
I0826 12:08:36.047990   50179 descheduler_verification.go:123] Waiting for namespace openshift-kube-descheduler-operator to be fully deleted...
I0826 12:08:41.247065   50179 descheduler_verification.go:123] Waiting for namespace openshift-kube-descheduler-operator to be fully deleted...
I0826 12:08:46.012138   50179 descheduler_verification.go:123] Waiting for namespace openshift-kube-descheduler-operator to be fully deleted...
I0826 12:08:51.026867   50179 descheduler_verification.go:123] Waiting for namespace openshift-kube-descheduler-operator to be fully deleted...
I0826 12:08:56.020502   50179 descheduler_verification.go:117] Namespace openshift-kube-descheduler-operator successfully deleted
•SSSSSSSSSSSSSSSSSS

Ran 1 of 20 Specs in 82.474 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 19 Skipped
--- PASS: TestE2E (82.48s)
PASS
ok  	github.com/openshift/cluster-kube-descheduler-operator/test/e2e	82.512s
```

// Failure logs:
```
  [FAILED] Unexpected error:
      <*fmt.wrapError | 0xbcec8603de0>: 
      failed to get packagemanifest cluster-kube-descheduler-operator: failed to get packagemanifest cluster-kube-descheduler-operator: packagemanifests.packages.operators.coreos.com "cluster-kube-descheduler-operator" not found
      {
          msg: "failed to get packagemanifest cluster-kube-descheduler-operator: failed to get packagemanifest cluster-kube-descheduler-operator: packagemanifests.packages.operators.coreos.com \"cluster-kube-descheduler-operator\" not found",
          err: <*fmt.wrapError | 0xbcec8603dc0>{
              msg: "failed to get packagemanifest cluster-kube-descheduler-operator: packagemanifests.packages.operators.coreos.com \"cluster-kube-descheduler-operator\" not found",
              err: <*errors.StatusError | 0xbcec80912c0>{
                  ErrStatus: {
                      TypeMeta: {Kind: "Status", APIVersion: "v1"},
                      ListMeta: {
                          SelfLink: "",
                          ResourceVersion: "",
                          Continue: "",
                          RemainingItemCount: nil,
                          ShardInfo: nil,
                      },
                      Status: "Failure",
                      Message: "packagemanifests.packages.operators.coreos.com \"cluster-kube-descheduler-operator\" not found",
                      Reason: "NotFound",
                      Details: {
                          Name: "cluster-kube-descheduler-operator",
                          Group: "packages.operators.coreos.com",
                          Kind: "packagemanifests",
                          UID: "",
                          Causes: nil,
                          RetryAfterSeconds: 0,
                      },
                      Code: 404,
                  },
              },
          },
      }
  occurred
  In [BeforeAll] at: /home/ropatil/Downloads/cntrlplane-2154/cluster-kube-descheduler-operator/test/e2e/descheduler_verification.go:72 @ 08/24/26 20:57:32.217
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Summary by CodeRabbit

- **Tests**
  - Expanded descheduler verification across multiple catalog sources.
  - Added diagnostics for unavailable packages and invalid catalog data.
  - Improved validation of operator installation, lifecycle, stability, and policies.
  - Enhanced setup and cleanup of namespaces, subscriptions, and operator resources.
  - Cleanup now runs conditionally with dedicated time limits for more reliable completion.
  - Improved automatic subscription approval and resource conversion handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->