### PR TITLE
[release-4.21] vendor: switch descheduler replace to openshift/descheduler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,10 +35,7 @@ require (
 
 // the softtainter is used in conjuction with KubevirtMigrationAware plugin that
 // is registered by github.com/openshift/descheduler but not in sigs.k8s.io/descheduler
-// replace sigs.k8s.io/descheduler => github.com/openshift/descheduler v0.0.0-20260610143345-3065c344e907
-// TODO: replace with github.com/openshift/descheduler once https://github.com/openshift/descheduler/pull/937
-// gets merged
-replace sigs.k8s.io/descheduler => github.com/tiraboschi/descheduler v0.0.0-20260730151803-6e8c772fd028
+replace sigs.k8s.io/descheduler => github.com/openshift/descheduler v0.0.0-20260819082048-43b39792d6ab
 
 replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b
 

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/openshift/build-machinery-go v0.0.0-20251023084048-5d77c1a5e5af h1:Ui
 github.com/openshift/build-machinery-go v0.0.0-20251023084048-5d77c1a5e5af/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20251015124057-db0dee36e235 h1:9JBeIXmnHlpXTQPi7LPmu1jdxznBhAE7bb1K+3D8gxY=
 github.com/openshift/client-go v0.0.0-20251015124057-db0dee36e235/go.mod h1:L49W6pfrZkfOE5iC1PqEkuLkXG4W0BX4w8b+L2Bv7fM=
+github.com/openshift/descheduler v0.0.0-20260819082048-43b39792d6ab h1:SRaUAhdhPj7fCebzAi12c+SL/6j9X7LZZoZNqBHcKbM=
+github.com/openshift/descheduler v0.0.0-20260819082048-43b39792d6ab/go.mod h1:rul3Lw3/DQiJEA1tE8TFppBM5w1MWw58v7f4GhXNbnc=
 github.com/openshift/library-go v0.0.0-20251021141706-f489e811f030 h1:dbv8ZYDWIl22A5WBjQJTKeENM08f8HwMBuv8glDXO/0=
 github.com/openshift/library-go v0.0.0-20251021141706-f489e811f030/go.mod h1:OlFFws1AO51uzfc48MsStGE4SFMWlMZD0+f5a/zCtKI=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
@@ -222,8 +224,6 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/tiraboschi/descheduler v0.0.0-20260730151803-6e8c772fd028 h1:a/ZYHOI/sObsnDn4SqwmxyLU2D/T2x2uTa7rjlNMsas=
-github.com/tiraboschi/descheduler v0.0.0-20260730151803-6e8c772fd028/go.mod h1:rul3Lw3/DQiJEA1tE8TFppBM5w1MWw58v7f4GhXNbnc=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7otjonDflCTK0BCfls4SPy3NcCVb5dqqmbRknE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75/go.mod h1:KO6IkyS8Y3j8OdNO85qEYBsRPuteD+YciPomcXdrMnk=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1644,7 +1644,7 @@ sigs.k8s.io/controller-tools/pkg/schemapatcher
 sigs.k8s.io/controller-tools/pkg/schemapatcher/internal/yaml
 sigs.k8s.io/controller-tools/pkg/version
 sigs.k8s.io/controller-tools/pkg/webhook
-# sigs.k8s.io/descheduler v0.33.1-0.20251021190039-e3503d22f457 => github.com/tiraboschi/descheduler v0.0.0-20260730151803-6e8c772fd028
+# sigs.k8s.io/descheduler v0.33.1-0.20251021190039-e3503d22f457 => github.com/openshift/descheduler v0.0.0-20260819082048-43b39792d6ab
 ## explicit; go 1.24.0
 sigs.k8s.io/descheduler/cmd/descheduler/app/options
 sigs.k8s.io/descheduler/metrics
@@ -1704,5 +1704,5 @@ sigs.k8s.io/structured-merge-diff/v6/value
 # sigs.k8s.io/yaml v1.6.0
 ## explicit; go 1.22
 sigs.k8s.io/yaml
-# sigs.k8s.io/descheduler => github.com/tiraboschi/descheduler v0.0.0-20260730151803-6e8c772fd028
+# sigs.k8s.io/descheduler => github.com/openshift/descheduler v0.0.0-20260819082048-43b39792d6ab
 # k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b


### PR DESCRIPTION
Now that https://github.com/openshift/descheduler/pull/937 is merged, replace the temporary tiraboschi/descheduler fork with the official openshift/descheduler which includes KubevirtMigrationAware plugin registration.