### PR TITLE
no-jira: fix(e2e): set NO_OLM=true when running via make test-e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ $(call add-crd-gen,descheduler,./pkg/apis/descheduler/v1,./manifests,./manifests
 
 test-e2e: GO_TEST_PACKAGES :=./test/e2e
 test-e2e: GO_TEST_ARGS :=-v -timeout 0
+test-e2e: export NO_OLM = "true"
 test-e2e: test-unit
 .PHONY: test-e2e
 

--- a/test/e2e/descheduler_verification.go
+++ b/test/e2e/descheduler_verification.go
@@ -41,7 +41,7 @@ const (
 )
 
 func isOperatorOLMInstallationEnabled() bool {
-	return os.Getenv("OPERATOR_IMAGE") == "" || os.Getenv("OPERAND_IMAGE") == ""
+	return os.Getenv("NO_OLM") == "" && os.Getenv("OPERATOR_IMAGE") == "" && os.Getenv("OPERAND_IMAGE") == ""
 }
 
 // Ginkgo test specs for migrated OTP tests


### PR DESCRIPTION
Install the operator images via operatorgroup by default. Setting explicit images needs to be explicitly enabled.

The OpenShift CI exposes `RELEASE_IMAGE_LATEST` and `NAMESPACE` envs which are used to automatically parse the operator image. Yet, the new test suite assumes operatorgroup based installation is the default one. So adding `NO_OLM` allows to explicitly override this default installation and prefer the envs instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * End-to-end tests now consistently skip OLM-based installation when alternative operator or operand images are configured.
  * Test execution explicitly disables OLM installation by default for the end-to-end test target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->