### PR TITLE
no-jira: chore: bump rate limits

### DIFF
--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/dynamic"
 	k8sclient "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 
@@ -40,6 +41,10 @@ func GetKubeClient() *k8sclient.Clientset {
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	o.Expect(err).NotTo(o.HaveOccurred(), "should build kubeconfig")
 
+	// Increase rate limits for test execution
+	config.QPS = rest.DefaultQPS * 10
+	config.Burst = rest.DefaultBurst * 10
+
 	client, err := k8sclient.NewForConfig(config)
 	o.Expect(err).NotTo(o.HaveOccurred(), "should create kubernetes client")
 
@@ -52,6 +57,10 @@ func GetApiExtensionClient() *apiextclientv1.Clientset {
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	o.Expect(err).NotTo(o.HaveOccurred(), "should build kubeconfig")
 
+	// Increase rate limits for test execution
+	config.QPS = rest.DefaultQPS * 10
+	config.Burst = rest.DefaultBurst * 10
+
 	client, err := apiextclientv1.NewForConfig(config)
 	o.Expect(err).NotTo(o.HaveOccurred(), "should create API extension client")
 
@@ -63,6 +72,10 @@ func GetDeschedulerClient() *deschclient.Clientset {
 	kubeconfig := os.Getenv("KUBECONFIG")
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	o.Expect(err).NotTo(o.HaveOccurred(), "should build kubeconfig")
+
+	// Increase rate limits for test execution
+	config.QPS = rest.DefaultQPS * 10
+	config.Burst = rest.DefaultBurst * 10
 
 	client, err := deschclient.NewForConfig(config)
 	o.Expect(err).NotTo(o.HaveOccurred(), "should create Descheduler client")
@@ -99,6 +112,10 @@ func GetDynamicClient() dynamic.Interface {
 	kubeconfig := os.Getenv("KUBECONFIG")
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	o.Expect(err).NotTo(o.HaveOccurred(), "should build kubeconfig")
+
+	// Increase rate limits for test execution
+	config.QPS = rest.DefaultQPS * 10
+	config.Burst = rest.DefaultBurst * 10
 
 	client, err := dynamic.NewForConfig(config)
 	o.Expect(err).NotTo(o.HaveOccurred(), "should create dynamic client")


### PR DESCRIPTION
To avoid rate limit reached errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved end-to-end test interactions with Kubernetes APIs by increasing client request throughput and burst capacity.
  * Added REST client configuration to support more reliable high-volume test operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->