### PR TITLE
OCPBUGS-113708: fix(operator): correct metrics port and add observability infrastructure

### DIFF
--- a/deploy/01_namespace.yaml
+++ b/deploy/01_namespace.yaml
@@ -3,4 +3,11 @@ kind: Namespace
 metadata:
   labels:
     openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/warn-version: latest
+    security.openshift.io/scc.podSecurityLabelSync: "true"
   name: openshift-kube-descheduler-operator

--- a/deploy/05_deployment.yaml
+++ b/deploy/05_deployment.yaml
@@ -25,8 +25,26 @@ spec:
           image: quay.io/openshift/origin-cluster-kube-descheduler-operator:latest
           terminationMessagePolicy: FallbackToLogsOnError
           ports:
-          - containerPort: 60000
-            name: metrics
+          - containerPort: 8443
+            name: https
+          resources:
+            requests:
+              cpu: 10m
+              memory: 50Mi
+          livenessProbe:
+            httpGet:
+              scheme: HTTPS
+              port: 8443
+              path: /healthz
+            initialDelaySeconds: 45
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              scheme: HTTPS
+              port: 8443
+              path: /healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
           command:
           - cluster-kube-descheduler-operator
           args:
@@ -52,8 +70,15 @@ spec:
           volumeMounts:
           - name: tmp
             mountPath: "/tmp"
+          - name: serving-cert
+            mountPath: /var/run/secrets/serving-cert
+            readOnly: true
       serviceAccountName: openshift-descheduler
       serviceAccount: openshift-descheduler
       volumes:
       - name: tmp
         emptyDir: {}
+      - name: serving-cert
+        secret:
+          secretName: descheduler-operator-serving-cert
+          optional: true

--- a/deploy/06_service.yaml
+++ b/deploy/06_service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: descheduler-operator-metrics
+  namespace: openshift-kube-descheduler-operator
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: descheduler-operator-serving-cert
+  labels:
+    name: descheduler-operator
+spec:
+  selector:
+    name: descheduler-operator
+  ports:
+    - name: https
+      port: 8443
+      targetPort: 8443
+      protocol: TCP

--- a/deploy/07_servicemonitor.yaml
+++ b/deploy/07_servicemonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: descheduler-operator
+  namespace: openshift-kube-descheduler-operator
+spec:
+  selector:
+    matchLabels:
+      name: descheduler-operator
+  endpoints:
+    - port: https
+      scheme: https
+      interval: 30s
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        serverName: descheduler-operator-metrics.openshift-kube-descheduler-operator.svc

--- a/manifests/cluster-kube-descheduler-operator.clusterserviceversion.yaml
+++ b/manifests/cluster-kube-descheduler-operator.clusterserviceversion.yaml
@@ -495,8 +495,22 @@ spec:
                         memory: 50Mi
                         cpu: 10m
                     ports:
-                      - containerPort: 60000
-                        name: metrics
+                      - containerPort: 8443
+                        name: https
+                    livenessProbe:
+                      httpGet:
+                        scheme: HTTPS
+                        port: 8443
+                        path: /healthz
+                      initialDelaySeconds: 45
+                      timeoutSeconds: 10
+                    readinessProbe:
+                      httpGet:
+                        scheme: HTTPS
+                        port: 8443
+                        path: /healthz
+                      initialDelaySeconds: 10
+                      timeoutSeconds: 10
                     command:
                       - cluster-kube-descheduler-operator
                     args:
@@ -520,8 +534,15 @@ spec:
                     volumeMounts:
                       - name: tmp
                         mountPath: "/tmp"
+                      - name: serving-cert
+                        mountPath: /var/run/secrets/serving-cert
+                        readOnly: true
                 serviceAccountName: openshift-descheduler
                 volumes:
                   - name: tmp
                     emptyDir: {}
+                  - name: serving-cert
+                    secret:
+                      secretName: descheduler-operator-serving-cert
+                      optional: true
     strategy: deployment

--- a/manifests/operator-service.yaml
+++ b/manifests/operator-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: descheduler-operator-metrics
+  namespace: openshift-kube-descheduler-operator
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: descheduler-operator-serving-cert
+  labels:
+    name: descheduler-operator
+spec:
+  selector:
+    name: descheduler-operator
+  ports:
+    - name: https
+      port: 8443
+      targetPort: 8443
+      protocol: TCP

--- a/manifests/operator-servicemonitor.yaml
+++ b/manifests/operator-servicemonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: descheduler-operator
+  namespace: openshift-kube-descheduler-operator
+spec:
+  selector:
+    matchLabels:
+      name: descheduler-operator
+  endpoints:
+    - port: https
+      scheme: https
+      interval: 30s
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        serverName: descheduler-operator-metrics.openshift-kube-descheduler-operator.svc

--- a/test/e2e/bindata/assets/05_deployment.yaml
+++ b/test/e2e/bindata/assets/05_deployment.yaml
@@ -35,8 +35,22 @@ spec:
               memory: 50Mi
               cpu: 10m
           ports:
-          - containerPort: 60000
-            name: metrics
+          - containerPort: 8443
+            name: https
+          livenessProbe:
+            httpGet:
+              scheme: HTTPS
+              port: 8443
+              path: /healthz
+            initialDelaySeconds: 45
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              scheme: HTTPS
+              port: 8443
+              path: /healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
           command:
           - cluster-kube-descheduler-operator
           args:
@@ -56,7 +70,14 @@ spec:
           volumeMounts:
           - name: tmp
             mountPath: "/tmp"
+          - name: serving-cert
+            mountPath: /var/run/secrets/serving-cert
+            readOnly: true
       serviceAccountName: openshift-descheduler
       volumes:
       - name: tmp
         emptyDir: {}
+      - name: serving-cert
+        secret:
+          secretName: descheduler-operator-serving-cert
+          optional: true

--- a/test/e2e/bindata/assets/08_operator-service.yaml
+++ b/test/e2e/bindata/assets/08_operator-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: descheduler-operator-metrics
+  namespace: openshift-kube-descheduler-operator
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: descheduler-operator-serving-cert
+  labels:
+    name: descheduler-operator
+spec:
+  selector:
+    name: descheduler-operator
+  ports:
+    - name: https
+      port: 8443
+      targetPort: 8443
+      protocol: TCP


### PR DESCRIPTION
Hi Team,

PTAL on the PR.

The operator deployment declared containerPort 60000 but the binary (via library-go's controllercmd) listens on 8443. This prevented metrics scraping, health probes, and TLS serving.

- Port: 60000 → 8443 (rename: metrics → https)
- Add liveness/readiness probes (HTTPS 8443 /healthz)
- Add resource requests, serving-cert volume, Service, ServiceMonitor
- Update deploy/, manifests/, test/e2e/ consistently
- Verified: /healthz returns HTTP 200

Image: quay.io/rhn_support_ropatil/kube-descheduler-operator@sha256:c7c93b62465d429ea776280df6707cca5b085ac0ddcf0f2e08754e88f48c1932

// Verification
```
oc get pods -n openshift-kube-descheduler-operator -o wide
NAME                                   READY   STATUS    RESTARTS      AGE   IP            NODE                                        NOMINATED NODE   READINESS GATES
descheduler-55cb78f958-9fq99           1/1     Running   1 (2s ago)    3s    10.129.2.55   ip-10-0-84-172.us-east-2.compute.internal   <none>           <none>
descheduler-operator-9766bf6bd-xqjjh   1/1     Running   1 (21m ago)   21m   10.129.2.46   ip-10-0-84-172.us-east-2.compute.internal   <none>           <none>

oc get pod -n openshift-kube-descheduler-operator  -l name=descheduler-operator \
 -o jsonpath='{.items[0].spec.containers[0].ports}' | jq 
[
  {
    "containerPort": 8443,
    "name": "https",
    "protocol": "TCP"
  }
]
```

// Before PR fix:
```
OPERATOR_POD_IP=$(oc get pod -n openshift-kube-descheduler-operator \
  -l name=descheduler-operator -o jsonpath='{.items[0].status.podIP}')
echo "Operator IP: $OPERATOR_POD_IP"
Operator IP: 10.129.2.38

oc run probe-test --image=busybox --rm -it --restart=Never -- \
  sh -c "wget -qO- --no-check-certificate --timeout=5 https://${OPERATOR_POD_IP}:60000 2>&1 && echo REACHABLE || echo UNREACHABLE"
All commands and output from this session will be recorded in container logs, including credentials and sensitive information passed through the command prompt.
If you don't see a command prompt, try pressing enter.
warning: couldn't attach to pod/probe-test, falling back to streaming logs: unable to upgrade connection: container probe-test not found in pod probe-test_default
wget: can't connect to remote host (10.129.2.38): Connection refused
UNREACHABLE
pod "probe-test" deleted from default namespace
```

// After PR fix:
```
oc run probe-test --image=busybox --rm -it --restart=Never --   sh -c "wget -qO- --no-check-certificate --timeout=5 https://${OPERATOR_POD_IP}:8443/healthz 2>&1 && echo REACHABLE || echo UNREACHABLE"
All commands and output from this session will be recorded in container logs, including credentials and sensitive information passed through the command prompt.
If you don't see a command prompt, try pressing enter.
warning: couldn't attach to pod/probe-test, falling back to streaming logs: unable to upgrade connection: container probe-test not found in pod probe-test_default
okREACHABLE
pod "probe-test" deleted from default namespace
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operator metrics are now exposed securely over HTTPS on port 8443.
  * Added authenticated, certificate-validated monitoring integration.
  * Added HTTPS health checks for improved readiness and availability reporting.
  * Added optional serving-certificate support and CPU and memory resource requests.

* **Security**
  * Updated namespace security labels and synchronized OpenShift pod-security settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->