### PR TITLE
NO-JIRA: add SKIP_OPERATOR_INSTALL support for upgrade CI testing

### DIFF
--- a/test/e2e/descheduler_verification.go
+++ b/test/e2e/descheduler_verification.go
@@ -44,6 +44,10 @@ func isOperatorOLMInstallationEnabled() bool {
 	return os.Getenv("NO_OLM") == "" && os.Getenv("OPERATOR_IMAGE") == "" && os.Getenv("OPERAND_IMAGE") == ""
 }
 
+func isSkipOperatorInstall() bool {
+	return os.Getenv("SKIP_OPERATOR_INSTALL") == "true"
+}
+
 // Ginkgo test specs for migrated OTP tests
 var _ = g.Describe("[OTP][Operator][Serial] Descheduler Operator Functionality", g.Ordered, g.Serial, func() {
 	var (
@@ -64,12 +68,16 @@ var _ = g.Describe("[OTP][Operator][Serial] Descheduler Operator Functionality",
 		apiExtClient = GetApiExtensionClient()
 		ctx, cancelFnc = context.WithCancel(context.TODO())
 
-		if !isOperatorOLMInstallationEnabled() {
+		if isSkipOperatorInstall() {
+			g.By("SKIP_OPERATOR_INSTALL=true: skipping operator installation")
+			klog.Infof("Skipping operator installation, assuming pre-verified by CI step")
+		} else if !isOperatorOLMInstallationEnabled() {
 			err = setupOperator(ctx, kubeClient, deschClient, apiExtClient)
+			o.Expect(err).NotTo(o.HaveOccurred())
 		} else {
 			err = installOperatorWithSubscription(ctx, kubeClient, deschClient, dynamicClient, operatorclient.OperatorNamespace)
+			o.Expect(err).NotTo(o.HaveOccurred())
 		}
-		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
 	g.AfterAll(func() {


### PR DESCRIPTION
Hi Team,

PTAL. 

When SKIP_OPERATOR_INSTALL=true is set, the e2e test suite skips operator installation in BeforeAll, allowing the tests to run against an already-running operator that was installed and verified by the CI step prior to test execution.

This supports the nightly 4.21→4.22 upgrade CI job where the operator is pre-installed via OLM, the cluster is upgraded, and the CI step verifies the operator health before invoking the test suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to skip operator installation during end-to-end test setup.

* **Bug Fixes**
  * Improved error handling so installation failures are reported immediately during test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->