### PR TITLE
NO_JIRA: add missing RBAC permissions

### DIFF
--- a/deploy/02_clusterrole.yaml
+++ b/deploy/02_clusterrole.yaml
@@ -177,6 +177,16 @@ rules:
       - patch
       - delete
   - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
       - config.openshift.io
     resources:
       - infrastructures

--- a/test/e2e/bindata/assets/03_clusterrole.yaml
+++ b/test/e2e/bindata/assets/03_clusterrole.yaml
@@ -177,6 +177,16 @@ rules:
       - patch
       - delete
   - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
       - config.openshift.io
     resources:
       - infrastructures


### PR DESCRIPTION
Hi Team,

PTAL

fix: add missing RBAC permissions for operator to manage operand
Add coordination.k8s.io/leases permissions to operator ClusterRole to allow the operator to grant leader election lease permissions to the operand. This is required for the operator to create the operand's ClusterRole without RBAC escalation prevention blocking it.

The operator needs to hold the same or broader permissions than what it grants to operands. Lease permissions are now included in both:
- deploy/02_clusterrole.yaml (cluster-scoped)
- test/e2e/bindata/assets/03_clusterrole.yaml (e2e test copy)

With these changes:
- Operator successfully creates operand ClusterRole
- Operand pod (descheduler) runs and evaluates descheduling policies
- All permissions follow least privilege (specific verbs, no wildcard)

// Error without these changes 
```
// if we do oc apply -f deploy 
oc logs -n openshift-kube-descheduler-operator -l name=descheduler-operator --tail=100
E0902 04:42:08.863003       1 target_config_reconciler.go:110] "unable to get operator configuration" err="kubedeschedulers.operator.openshift.io \"cluster\" not found" namespace="openshift-kube-descheduler-operator" kubedescheduler="cluster"
E0902 04:42:08.863015       1 target_config_reconciler.go:677] key failed with : kubedeschedulers.operator.openshift.io "cluster" not found
I0902 04:42:08.888104       1 shared_informer.go:318] Caches are synced for client-ca::kube-system::extension-apiserver-authentication::requestheader-client-ca-file
I0902 04:42:08.888148       1 shared_informer.go:318] Caches are synced for RequestHeaderAuthRequestController
I0902 04:42:08.888109       1 shared_informer.go:318] Caches are synced for client-ca::kube-system::extension-apiserver-authentication::client-ca-file
E0902 04:42:08.906660       1 target_config_reconciler.go:110] "unable to get operator configuration" err="kubedeschedulers.operator.openshift.io \"cluster\" not found" namespace="openshift-kube-descheduler-operator" kubedescheduler="cluster"
E0902 04:42:08.906674       1 target_config_reconciler.go:677] key failed with : kubedeschedulers.operator.openshift.io "cluster" not found
I0902 04:42:08.909705       1 base_controller.go:73] Caches are synced for ConfigObserver 
I0902 04:42:08.909719       1 base_controller.go:110] Starting #1 worker of ConfigObserver controller ...
I0902 04:42:08.909724       1 base_controller.go:73] Caches are synced for LoggingSyncer 
I0902 04:42:08.909750       1 base_controller.go:110] Starting #1 worker of LoggingSyncer controller ...
I0902 04:42:08.909779       1 base_controller.go:73] Caches are synced for ResourceSyncController 
I0902 04:42:08.909783       1 base_controller.go:110] Starting #1 worker of ResourceSyncController controller ...
E0902 04:42:08.914201       1 base_controller.go:268] ResourceSyncController reconciliation failed: kubedeschedulers.operator.openshift.io "cluster" not found
E0902 04:42:08.924307       1 base_controller.go:268] ResourceSyncController reconciliation failed: kubedeschedulers.operator.openshift.io "cluster" not found
E0902 04:42:08.937424       1 base_controller.go:268] ResourceSyncController reconciliation failed: kubedeschedulers.operator.openshift.io "cluster" not found
E0902 04:42:09.012930       1 base_controller.go:268] ResourceSyncController reconciliation failed: kubedeschedulers.operator.openshift.io "cluster" not found
E0902 04:42:09.214941       1 target_config_reconciler.go:110] "unable to get operator configuration" err="kubedeschedulers.operator.openshift.io \"cluster\" not found" namespace="openshift-kube-descheduler-operator" kubedescheduler="cluster"
E0902 04:42:09.214958       1 target_config_reconciler.go:677] key failed with : kubedeschedulers.operator.openshift.io "cluster" not found
E0902 04:42:09.414965       1 base_controller.go:268] ResourceSyncController reconciliation failed: kubedeschedulers.operator.openshift.io "cluster" not found
E0902 04:42:09.613955       1 target_config_reconciler.go:110] "unable to get operator configuration" err="kubedeschedulers.operator.openshift.io \"cluster\" not found" namespace="openshift-kube-descheduler-operator" kubedescheduler="cluster"
E0902 04:42:09.613974       1 target_config_reconciler.go:677] key failed with : kubedeschedulers.operator.openshift.io "cluster" not found
E0902 04:42:09.812885       1 base_controller.go:268] ResourceSyncController reconciliation failed: kubedeschedulers.operator.openshift.io "cluster" not found
E0902 04:42:10.014760       1 target_config_reconciler.go:110] "unable to get operator configuration" err="kubedeschedulers.operator.openshift.io \"cluster\" not found" namespace="openshift-kube-descheduler-operator" kubedescheduler="cluster"
E0902 04:42:10.014779       1 target_config_reconciler.go:677] key failed with : kubedeschedulers.operator.openshift.io "cluster" not found
E0902 04:42:10.215551       1 base_controller.go:268] ResourceSyncController reconciliation failed: kubedeschedulers.operator.openshift.io "cluster" not found
E0902 04:42:10.539630       1 base_controller.go:268] ResourceSyncController reconciliation failed: kubedeschedulers.operator.openshift.io "cluster" not found
E0902 04:42:10.658505       1 target_config_reconciler.go:110] "unable to get operator configuration" err="kubedeschedulers.operator.openshift.io \"cluster\" not found" namespace="openshift-kube-descheduler-operator" kubedescheduler="cluster"
E0902 04:42:10.658522       1 target_config_reconciler.go:677] key failed with : kubedeschedulers.operator.openshift.io "cluster" not found
E0902 04:42:11.184374       1 base_controller.go:268] ResourceSyncController reconciliation failed: kubedeschedulers.operator.openshift.io "cluster" not found
E0902 04:42:11.944735       1 target_config_reconciler.go:110] "unable to get operator configuration" err="kubedeschedulers.operator.openshift.io \"cluster\" not found" namespace="openshift-kube-descheduler-operator" kubedescheduler="cluster"
E0902 04:42:11.944751       1 target_config_reconciler.go:677] key failed with : kubedeschedulers.operator.openshift.io "cluster" not found
E0902 04:42:12.468149       1 base_controller.go:268] ResourceSyncController reconciliation failed: kubedeschedulers.operator.openshift.io "cluster" not found
E0902 04:42:14.508774       1 target_config_reconciler.go:110] "unable to get operator configuration" err="kubedeschedulers.operator.openshift.io \"cluster\" not found" namespace="openshift-kube-descheduler-operator" kubedescheduler="cluster"
E0902 04:42:14.508790       1 target_config_reconciler.go:677] key failed with : kubedeschedulers.operator.openshift.io "cluster" not found
E0902 04:42:15.033893       1 base_controller.go:268] ResourceSyncController reconciliation failed: kubedeschedulers.operator.openshift.io "cluster" not found
E0902 04:42:19.634828       1 target_config_reconciler.go:110] "unable to get operator configuration" err="kubedeschedulers.operator.openshift.io \"cluster\" not found" namespace="openshift-kube-descheduler-operator" kubedescheduler="cluster"
E0902 04:42:19.634846       1 target_config_reconciler.go:677] key failed with : kubedeschedulers.operator.openshift.io "cluster" not found
E0902 04:42:20.158923       1 base_controller.go:268] ResourceSyncController reconciliation failed: kubedeschedulers.operator.openshift.io "cluster" not found
E0902 04:42:29.879933       1 target_config_reconciler.go:110] "unable to get operator configuration" err="kubedeschedulers.operator.openshift.io \"cluster\" not found" namespace="openshift-kube-descheduler-operator" kubedescheduler="cluster"
E0902 04:42:29.879959       1 target_config_reconciler.go:677] key failed with : kubedeschedulers.operator.openshift.io "cluster" not found
E0902 04:42:30.403970       1 base_controller.go:268] ResourceSyncController reconciliation failed: kubedeschedulers.operator.openshift.io "cluster" not found
I0902 04:42:37.253683       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-descheduler-operator", Name:"descheduler-operator", UID:"a4282f6c-7757-4a9f-bfe4-f5450ed8911f", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'ObserveTLSSecurityProfile' minTLSVersion changed to VersionTLS12
I0902 04:42:37.253719       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-descheduler-operator", Name:"descheduler-operator", UID:"a4282f6c-7757-4a9f-bfe4-f5450ed8911f", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'ObserveTLSSecurityProfile' cipherSuites changed to ["TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256" "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256" "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384" "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256" "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"]
I0902 04:42:37.253857       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-descheduler-operator", Name:"descheduler-operator", UID:"a4282f6c-7757-4a9f-bfe4-f5450ed8911f", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'ObservedConfigChanged' Writing updated observed config:   map[string]any{
+ 	"servingInfo": map[string]any{
+ 		"cipherSuites": []any{
+ 			string("TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"),
+ 			string("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"),
+ 			string("TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"),
+ 			string("TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"),
+ 			string("TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256"),
+ 			string("TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"),
+ 		},
+ 		"minTLSVersion": string("VersionTLS12"),
+ 	},
  }
I0902 04:42:37.268782       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-descheduler-operator", Name:"descheduler-operator", UID:"a4282f6c-7757-4a9f-bfe4-f5450ed8911f", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'ConfigMapCreated' Created ConfigMap/cluster -n openshift-kube-descheduler-operator because it was missing
I0902 04:42:37.285938       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-descheduler-operator", Name:"descheduler-operator", UID:"a4282f6c-7757-4a9f-bfe4-f5450ed8911f", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'ServiceCreated' Created Service/metrics -n openshift-kube-descheduler-operator because it was missing
I0902 04:42:37.304092       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-descheduler-operator", Name:"descheduler-operator", UID:"a4282f6c-7757-4a9f-bfe4-f5450ed8911f", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'ServiceAccountCreated' Created ServiceAccount/openshift-descheduler-operand -n openshift-kube-descheduler-operator because it was missing
E0902 04:42:37.369403       1 target_config_reconciler.go:677] key failed with : clusterroles.rbac.authorization.k8s.io "openshift-descheduler-operand" is forbidden: user "system:serviceaccount:openshift-kube-descheduler-operator:openshift-descheduler" (groups=["system:serviceaccounts" "system:serviceaccounts:openshift-kube-descheduler-operator" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:
{APIGroups:["coordination.k8s.io"], Resources:["leases"], ResourceNames:["descheduler"], Verbs:["get" "patch" "delete"]}
{APIGroups:["coordination.k8s.io"], Resources:["leases"], Verbs:["create"]}
{APIGroups:["events.k8s.io"], Resources:["events"], Verbs:["*"]}
I0902 04:42:37.369476       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-descheduler-operator", Name:"descheduler-operator", UID:"a4282f6c-7757-4a9f-bfe4-f5450ed8911f", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ClusterRoleCreateFailed' Failed to create ClusterRole.rbac.authorization.k8s.io/openshift-descheduler-operand: clusterroles.rbac.authorization.k8s.io "openshift-descheduler-operand" is forbidden: user "system:serviceaccount:openshift-kube-descheduler-operator:openshift-descheduler" (groups=["system:serviceaccounts" "system:serviceaccounts:openshift-kube-descheduler-operator" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:
{APIGroups:["coordination.k8s.io"], Resources:["leases"], ResourceNames:["descheduler"], Verbs:["get" "patch" "delete"]}
{APIGroups:["coordination.k8s.io"], Resources:["leases"], Verbs:["create"]}
{APIGroups:["events.k8s.io"], Resources:["events"], Verbs:["*"]}
E0902 04:42:38.119084       1 target_config_reconciler.go:677] key failed with : clusterroles.rbac.authorization.k8s.io "openshift-descheduler-operand" is forbidden: user "system:serviceaccount:openshift-kube-descheduler-operator:openshift-descheduler" (groups=["system:serviceaccounts" "system:serviceaccounts:openshift-kube-descheduler-operator" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:
{APIGroups:["coordination.k8s.io"], Resources:["leases"], ResourceNames:["descheduler"], Verbs:["get" "patch" "delete"]}
{APIGroups:["coordination.k8s.io"], Resources:["leases"], Verbs:["create"]}
{APIGroups:["events.k8s.io"], Resources:["events"], Verbs:["*"]}
I0902 04:42:38.119139       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-descheduler-operator", Name:"descheduler-operator", UID:"a4282f6c-7757-4a9f-bfe4-f5450ed8911f", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ClusterRoleCreateFailed' Failed to create ClusterRole.rbac.authorization.k8s.io/openshift-descheduler-operand: clusterroles.rbac.authorization.k8s.io "openshift-descheduler-operand" is forbidden: user "system:serviceaccount:openshift-kube-descheduler-operator:openshift-descheduler" (groups=["system:serviceaccounts" "system:serviceaccounts:openshift-kube-descheduler-operator" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:
{APIGroups:["coordination.k8s.io"], Resources:["leases"], ResourceNames:["descheduler"], Verbs:["get" "patch" "delete"]}
{APIGroups:["coordination.k8s.io"], Resources:["leases"], Verbs:["create"]}
{APIGroups:["events.k8s.io"], Resources:["events"], Verbs:["*"]}
E0902 04:42:39.315306       1 target_config_reconciler.go:677] key failed with : clusterroles.rbac.authorization.k8s.io "openshift-descheduler-operand" is forbidden: user "system:serviceaccount:openshift-kube-descheduler-operator:openshift-descheduler" (groups=["system:serviceaccounts" "system:serviceaccounts:openshift-kube-descheduler-operator" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:
{APIGroups:["coordination.k8s.io"], Resources:["leases"], ResourceNames:["descheduler"], Verbs:["get" "patch" "delete"]}
{APIGroups:["coordination.k8s.io"], Resources:["leases"], Verbs:["create"]}
{APIGroups:["events.k8s.io"], Resources:["events"], Verbs:["*"]}
I0902 04:42:39.315385       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-descheduler-operator", Name:"descheduler-operator", UID:"a4282f6c-7757-4a9f-bfe4-f5450ed8911f", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ClusterRoleCreateFailed' Failed to create ClusterRole.rbac.authorization.k8s.io/openshift-descheduler-operand: clusterroles.rbac.authorization.k8s.io "openshift-descheduler-operand" is forbidden: user "system:serviceaccount:openshift-kube-descheduler-operator:openshift-descheduler" (groups=["system:serviceaccounts" "system:serviceaccounts:openshift-kube-descheduler-operator" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:
{APIGroups:["coordination.k8s.io"], Resources:["leases"], ResourceNames:["descheduler"], Verbs:["get" "patch" "delete"]}
{APIGroups:["coordination.k8s.io"], Resources:["leases"], Verbs:["create"]}
{APIGroups:["events.k8s.io"], Resources:["events"], Verbs:["*"]}
E0902 04:42:40.714824       1 target_config_reconciler.go:677] key failed with : clusterroles.rbac.authorization.k8s.io "openshift-descheduler-operand" is forbidden: user "system:serviceaccount:openshift-kube-descheduler-operator:openshift-descheduler" (groups=["system:serviceaccounts" "system:serviceaccounts:openshift-kube-descheduler-operator" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:
{APIGroups:["coordination.k8s.io"], Resources:["leases"], ResourceNames:["descheduler"], Verbs:["get" "patch" "delete"]}
{APIGroups:["coordination.k8s.io"], Resources:["leases"], Verbs:["create"]}
{APIGroups:["events.k8s.io"], Resources:["events"], Verbs:["*"]}
I0902 04:42:40.714860       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-descheduler-operator", Name:"descheduler-operator", UID:"a4282f6c-7757-4a9f-bfe4-f5450ed8911f", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ClusterRoleCreateFailed' Failed to create ClusterRole.rbac.authorization.k8s.io/openshift-descheduler-operand: clusterroles.rbac.authorization.k8s.io "openshift-descheduler-operand" is forbidden: user "system:serviceaccount:openshift-kube-descheduler-operator:openshift-descheduler" (groups=["system:serviceaccounts" "system:serviceaccounts:openshift-kube-descheduler-operator" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:
{APIGroups:["coordination.k8s.io"], Resources:["leases"], ResourceNames:["descheduler"], Verbs:["get" "patch" "delete"]}
{APIGroups:["coordination.k8s.io"], Resources:["leases"], Verbs:["create"]}
{APIGroups:["events.k8s.io"], Resources:["events"], Verbs:["*"]}
E0902 04:42:50.431144       1 target_config_reconciler.go:677] key failed with : clusterroles.rbac.authorization.k8s.io "openshift-descheduler-operand" is forbidden: user "system:serviceaccount:openshift-kube-descheduler-operator:openshift-descheduler" (groups=["system:serviceaccounts" "system:serviceaccounts:openshift-kube-descheduler-operator" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:
{APIGroups:["coordination.k8s.io"], Resources:["leases"], ResourceNames:["descheduler"], Verbs:["get" "patch" "delete"]}
{APIGroups:["coordination.k8s.io"], Resources:["leases"], Verbs:["create"]}
{APIGroups:["events.k8s.io"], Resources:["events"], Verbs:["*"]}
I0902 04:42:50.431224       1 event.go:364] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-descheduler-operator", Name:"descheduler-operator", UID:"a4282f6c-7757-4a9f-bfe4-f5450ed8911f", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ClusterRoleCreateFailed' Failed to create ClusterRole.rbac.authorization.k8s.io/openshift-descheduler-operand: clusterroles.rbac.authorization.k8s.io "openshift-descheduler-operand" is forbidden: user "system:serviceaccount:openshift-kube-descheduler-operator:openshift-descheduler" (groups=["system:serviceaccounts" "system:serviceaccounts:openshift-kube-descheduler-operator" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:
{APIGroups:["coordination.k8s.io"], Resources:["leases"], ResourceNames:["descheduler"], Verbs:["get" "patch" "delete"]}
{APIGroups:["coordination.k8s.io"], Resources:["leases"], Verbs:["create"]}
{APIGroups:["events.k8s.io"], Resources:["events"], Verbs:["*"]}
```