### PR TITLE
NO-JIRA:  Fix namespace handling and ServiceMonitor TLS for non-default namespace deployments

### DIFF
--- a/cmd/soft-tainter/main.go
+++ b/cmd/soft-tainter/main.go
@@ -104,10 +104,8 @@ func main() {
 	// Setup a Manager
 	entryLog.Info("setting up manager")
 	needLeaderElection := true
-	operatorNamespace := os.Getenv("OPERATOR_POD_NAMESPACE")
-	if operatorNamespace == "" {
-		operatorNamespace = operatorclient.OperatorNamespace
-	}
+	// NOTE: For custom namespace support in future, WATCH_NAMESPACE env should be assigned to operatorNamespace
+	operatorNamespace := operatorclient.OperatorNamespace
 	mgr, err := manager.New(config.GetConfigOrDie(), getManagerOptions(operatorNamespace, needLeaderElection, scheme))
 	if err != nil {
 		entryLog.Error(err, "unable to set up overall controller manager")

--- a/cmd/soft-tainter/main.go
+++ b/cmd/soft-tainter/main.go
@@ -104,7 +104,11 @@ func main() {
 	// Setup a Manager
 	entryLog.Info("setting up manager")
 	needLeaderElection := true
-	mgr, err := manager.New(config.GetConfigOrDie(), getManagerOptions(operatorclient.OperatorNamespace, needLeaderElection, scheme))
+	operatorNamespace := os.Getenv("OPERATOR_POD_NAMESPACE")
+	if operatorNamespace == "" {
+		operatorNamespace = operatorclient.OperatorNamespace
+	}
+	mgr, err := manager.New(config.GetConfigOrDie(), getManagerOptions(operatorNamespace, needLeaderElection, scheme))
 	if err != nil {
 		entryLog.Error(err, "unable to set up overall controller manager")
 		os.Exit(1)
@@ -122,7 +126,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	err = softtainter.RegisterReconciler(mgr, policyConfigFile)
+	err = softtainter.RegisterReconciler(mgr, policyConfigFile, operatorNamespace)
 	if err != nil {
 		entryLog.Error(err, "unable to register the controller")
 		os.Exit(1)

--- a/deploy/07_servicemonitor.yaml
+++ b/deploy/07_servicemonitor.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: descheduler-operator
-  namespace: openshift-kube-descheduler-operator
 spec:
   selector:
     matchLabels:

--- a/deploy/07_servicemonitor.yaml
+++ b/deploy/07_servicemonitor.yaml
@@ -14,4 +14,12 @@ spec:
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       tlsConfig:
         caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-        serverName: descheduler-operator-metrics.openshift-kube-descheduler-operator.svc
+      relabelings:
+        - sourceLabels:
+            - __meta_kubernetes_service_name
+            - __meta_kubernetes_namespace
+          separator: "."
+          regex: "(.*)"
+          targetLabel: __address__
+          replacement: "${1}.svc:8443"
+          action: replace

--- a/manifests/operator-service.yaml
+++ b/manifests/operator-service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: descheduler-operator-metrics
-  namespace: openshift-kube-descheduler-operator
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: descheduler-operator-serving-cert
   labels:

--- a/manifests/operator-servicemonitor.yaml
+++ b/manifests/operator-servicemonitor.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: descheduler-operator
-  namespace: openshift-kube-descheduler-operator
 spec:
   selector:
     matchLabels:
@@ -14,4 +13,14 @@ spec:
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       tlsConfig:
         caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-        serverName: descheduler-operator-metrics.openshift-kube-descheduler-operator.svc
+      # Scrape via Service DNS so TLS hostname is <service>.<namespace>.svc,
+      # matching the serving-cert SAN in any install namespace. Do not hardcode serverName.
+      relabelings:
+        - sourceLabels:
+            - __meta_kubernetes_service_name
+            - __meta_kubernetes_namespace
+          separator: "."
+          regex: "(.*)"
+          targetLabel: __address__
+          replacement: "${1}.svc:8443"
+          action: replace

--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -5,7 +5,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/openshift/cluster-kube-descheduler-operator/pkg/operator/configobservation"
-	"github.com/openshift/cluster-kube-descheduler-operator/pkg/operator/operatorclient"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/configobserver"
 	libgoapiserver "github.com/openshift/library-go/pkg/operator/configobserver/apiserver"
@@ -24,9 +23,10 @@ func NewConfigObserver(
 	configInformer configinformers.SharedInformerFactory,
 	resourceSyncer resourcesynccontroller.ResourceSyncer,
 	eventRecorder events.Recorder,
+	operatorNamespace string,
 ) *ConfigObserver {
 	interestingNamespaces := []string{
-		operatorclient.OperatorNamespace,
+		operatorNamespace,
 	}
 
 	informers := []factory.Informer{

--- a/pkg/operator/operatorclient/interfaces.go
+++ b/pkg/operator/operatorclient/interfaces.go
@@ -32,6 +32,7 @@ const PromRouteName = "prometheus-k8s"
 
 type DeschedulerClient struct {
 	Ctx            context.Context
+	Namespace      string
 	SharedInformer cache.SharedIndexInformer
 	OperatorClient operatorconfigclientv1.KubedeschedulersV1Interface
 }
@@ -40,8 +41,12 @@ func (c *DeschedulerClient) Informer() cache.SharedIndexInformer {
 	return c.SharedInformer
 }
 
+func (c *DeschedulerClient) GetNamespace() string {
+	return c.Namespace
+}
+
 func (c *DeschedulerClient) GetOperatorState() (spec *operatorv1.OperatorSpec, status *operatorv1.OperatorStatus, resourceVersion string, err error) {
-	instance, err := c.OperatorClient.KubeDeschedulers(OperatorNamespace).Get(c.Ctx, OperatorConfigName, metav1.GetOptions{})
+	instance, err := c.OperatorClient.KubeDeschedulers(c.Namespace).Get(c.Ctx, OperatorConfigName, metav1.GetOptions{})
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -53,7 +58,7 @@ func (c *DeschedulerClient) GetOperatorStateWithQuorum(ctx context.Context) (*op
 }
 
 func (c *DeschedulerClient) UpdateOperatorSpec(ctx context.Context, resourceVersion string, spec *operatorv1.OperatorSpec) (out *operatorv1.OperatorSpec, newResourceVersion string, err error) {
-	original, err := c.OperatorClient.KubeDeschedulers(OperatorNamespace).Get(ctx, OperatorConfigName, metav1.GetOptions{})
+	original, err := c.OperatorClient.KubeDeschedulers(c.Namespace).Get(ctx, OperatorConfigName, metav1.GetOptions{})
 	if err != nil {
 		return nil, "", err
 	}
@@ -61,7 +66,7 @@ func (c *DeschedulerClient) UpdateOperatorSpec(ctx context.Context, resourceVers
 	copy.ResourceVersion = resourceVersion
 	copy.Spec.OperatorSpec = *spec
 
-	ret, err := c.OperatorClient.KubeDeschedulers(OperatorNamespace).Update(ctx, copy, v1.UpdateOptions{})
+	ret, err := c.OperatorClient.KubeDeschedulers(c.Namespace).Update(ctx, copy, v1.UpdateOptions{})
 	if err != nil {
 		return nil, "", err
 	}
@@ -70,7 +75,7 @@ func (c *DeschedulerClient) UpdateOperatorSpec(ctx context.Context, resourceVers
 }
 
 func (c *DeschedulerClient) UpdateOperatorStatus(ctx context.Context, resourceVersion string, status *operatorv1.OperatorStatus) (out *operatorv1.OperatorStatus, err error) {
-	original, err := c.OperatorClient.KubeDeschedulers(OperatorNamespace).Get(ctx, OperatorConfigName, metav1.GetOptions{})
+	original, err := c.OperatorClient.KubeDeschedulers(c.Namespace).Get(ctx, OperatorConfigName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +83,7 @@ func (c *DeschedulerClient) UpdateOperatorStatus(ctx context.Context, resourceVe
 	copy.ResourceVersion = resourceVersion
 	copy.Status.OperatorStatus = *status
 
-	ret, err := c.OperatorClient.KubeDeschedulers(OperatorNamespace).UpdateStatus(ctx, copy, v1.UpdateOptions{})
+	ret, err := c.OperatorClient.KubeDeschedulers(c.Namespace).UpdateStatus(ctx, copy, v1.UpdateOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +92,7 @@ func (c *DeschedulerClient) UpdateOperatorStatus(ctx context.Context, resourceVe
 }
 
 func (c *DeschedulerClient) GetObjectMeta() (meta *metav1.ObjectMeta, err error) {
-	instance, err := c.OperatorClient.KubeDeschedulers(OperatorNamespace).Get(c.Ctx, OperatorConfigName, metav1.GetOptions{})
+	instance, err := c.OperatorClient.KubeDeschedulers(c.Namespace).Get(c.Ctx, OperatorConfigName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -102,10 +107,10 @@ func (c *DeschedulerClient) ApplyOperatorSpec(ctx context.Context, fieldManager 
 	desiredSpec := &deschedulerapplyconfiguration.KubeDeschedulerSpecApplyConfiguration{
 		OperatorSpecApplyConfiguration: *desiredConfiguration,
 	}
-	desired := deschedulerapplyconfiguration.KubeDescheduler(OperatorConfigName, OperatorNamespace)
+	desired := deschedulerapplyconfiguration.KubeDescheduler(OperatorConfigName, c.Namespace)
 	desired.WithSpec(desiredSpec)
 
-	instance, err := c.OperatorClient.KubeDeschedulers(OperatorNamespace).Get(ctx, OperatorConfigName, metav1.GetOptions{})
+	instance, err := c.OperatorClient.KubeDeschedulers(c.Namespace).Get(ctx, OperatorConfigName, metav1.GetOptions{})
 	switch {
 	case apierrors.IsNotFound(err):
 	// do nothing and proceed with the apply
@@ -121,7 +126,7 @@ func (c *DeschedulerClient) ApplyOperatorSpec(ctx context.Context, fieldManager 
 		}
 	}
 
-	_, err = c.OperatorClient.KubeDeschedulers(OperatorNamespace).Apply(ctx, desired, v1.ApplyOptions{
+	_, err = c.OperatorClient.KubeDeschedulers(c.Namespace).Apply(ctx, desired, v1.ApplyOptions{
 		Force:        true,
 		FieldManager: fieldManager,
 	})
@@ -140,10 +145,10 @@ func (c *DeschedulerClient) ApplyOperatorStatus(ctx context.Context, fieldManage
 	desiredStatus := &deschedulerapplyconfiguration.KubeDeschedulerStatusApplyConfiguration{
 		OperatorStatusApplyConfiguration: *desiredConfiguration,
 	}
-	desired := deschedulerapplyconfiguration.KubeDescheduler(OperatorConfigName, OperatorNamespace)
+	desired := deschedulerapplyconfiguration.KubeDescheduler(OperatorConfigName, c.Namespace)
 	desired.WithStatus(desiredStatus)
 
-	instance, err := c.OperatorClient.KubeDeschedulers(OperatorNamespace).Get(ctx, OperatorConfigName, metav1.GetOptions{})
+	instance, err := c.OperatorClient.KubeDeschedulers(c.Namespace).Get(ctx, OperatorConfigName, metav1.GetOptions{})
 	switch {
 	case apierrors.IsNotFound(err):
 		// do nothing and proceed with the apply
@@ -165,7 +170,7 @@ func (c *DeschedulerClient) ApplyOperatorStatus(ctx context.Context, fieldManage
 		}
 	}
 
-	_, err = c.OperatorClient.KubeDeschedulers(OperatorNamespace).ApplyStatus(ctx, desired, v1.ApplyOptions{
+	_, err = c.OperatorClient.KubeDeschedulers(c.Namespace).ApplyStatus(ctx, desired, v1.ApplyOptions{
 		Force:        true,
 		FieldManager: fieldManager,
 	})
@@ -181,6 +186,6 @@ func (c *DeschedulerClient) PatchOperatorStatus(ctx context.Context, jsonPatch *
 	if err != nil {
 		return err
 	}
-	_, err = c.OperatorClient.KubeDeschedulers(OperatorNamespace).Patch(ctx, OperatorConfigName, types.JSONPatchType, jsonPatchBytes, metav1.PatchOptions{}, "/status")
+	_, err = c.OperatorClient.KubeDeschedulers(c.Namespace).Patch(ctx, OperatorConfigName, types.JSONPatchType, jsonPatchBytes, metav1.PatchOptions{}, "/status")
 	return err
 }

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -56,10 +56,16 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 		return err
 	}
 
+	operatorNamespace := os.Getenv("OPERATOR_POD_NAMESPACE")
+	if operatorNamespace == "" {
+		operatorNamespace = operatorclient.OperatorNamespace
+	}
+	klog.Infof("Operator running in namespace: %s", operatorNamespace)
+
 	kubeInformersForNamespaces := v1helpers.NewKubeInformersForNamespaces(
 		kubeClient,
 		"",
-		operatorclient.OperatorNamespace,
+		operatorNamespace,
 	)
 
 	operatorConfigClient, err := operatorconfigclient.NewForConfig(cc.KubeConfig)
@@ -69,6 +75,7 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 	operatorConfigInformers := operatorclientinformers.NewSharedInformerFactory(operatorConfigClient, 10*time.Minute)
 	deschedulerClient := &operatorclient.DeschedulerClient{
 		Ctx:            ctx,
+		Namespace:      operatorNamespace,
 		SharedInformer: operatorConfigInformers.Kubedeschedulers().V1().KubeDeschedulers().Informer(),
 		OperatorClient: operatorConfigClient.KubedeschedulersV1(),
 	}
@@ -89,6 +96,7 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 		configInformers,
 		resourceSyncController,
 		cc.EventRecorder,
+		operatorNamespace,
 	)
 
 	targetConfigReconciler := NewTargetConfigReconciler(

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -56,10 +56,8 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 		return err
 	}
 
-	operatorNamespace := os.Getenv("OPERATOR_POD_NAMESPACE")
-	if operatorNamespace == "" {
-		operatorNamespace = operatorclient.OperatorNamespace
-	}
+	// NOTE: For custom namespace support in future, WATCH_NAMESPACE env should be assigned to operatorNamespace
+	operatorNamespace := operatorclient.OperatorNamespace
 	klog.Infof("Operator running in namespace: %s", operatorNamespace)
 
 	kubeInformersForNamespaces := v1helpers.NewKubeInformersForNamespaces(

--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -1169,18 +1169,6 @@ func (c *TargetConfigReconciler) manageSoftTainterDeployment(descheduler *desche
 	required := resourceread.ReadDeploymentV1OrDie(bindata.MustAsset("assets/kube-descheduler/softtainterdeployment.yaml"))
 	required.Name = operatorclient.SoftTainterOperandName
 	required.Namespace = descheduler.Namespace
-	if len(required.Spec.Template.Spec.Containers) > 0 {
-		required.Spec.Template.Spec.Containers[0].Env = append(required.Spec.Template.Spec.Containers[0].Env,
-			v1.EnvVar{
-				Name: "OPERATOR_POD_NAMESPACE",
-				ValueFrom: &v1.EnvVarSource{
-					FieldRef: &v1.ObjectFieldSelector{
-						FieldPath: "metadata.namespace",
-					},
-				},
-			},
-		)
-	}
 	if stEnabled {
 		return c.manageDeployment(required, descheduler, targetImageKey, c.softtainterImagePullSpec, specAnnotations)
 	}

--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -142,13 +142,14 @@ func NewTargetConfigReconciler(
 }
 
 func (c TargetConfigReconciler) scaleDownDeployment(scaleDownError error) error {
-	_, err := c.kubeClient.AppsV1().Deployments(operatorclient.OperatorNamespace).UpdateScale(
+	operatorNamespace := c.deschedulerClient.GetNamespace()
+	_, err := c.kubeClient.AppsV1().Deployments(operatorNamespace).UpdateScale(
 		c.ctx,
 		operatorclient.OperandName,
 		&autoscalingv1.Scale{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      operatorclient.OperandName,
-				Namespace: operatorclient.OperatorNamespace,
+				Namespace: operatorNamespace,
 			},
 			Spec: autoscalingv1.ScaleSpec{
 				Replicas: 0,
@@ -168,9 +169,10 @@ func (c TargetConfigReconciler) scaleDownDeployment(scaleDownError error) error 
 }
 
 func (c TargetConfigReconciler) sync() error {
-	descheduler, err := c.operatorClient.KubeDeschedulers(operatorclient.OperatorNamespace).Get(c.ctx, operatorclient.OperatorConfigName, metav1.GetOptions{})
+	operatorNamespace := c.deschedulerClient.GetNamespace()
+	descheduler, err := c.operatorClient.KubeDeschedulers(operatorNamespace).Get(c.ctx, operatorclient.OperatorConfigName, metav1.GetOptions{})
 	if err != nil {
-		klog.ErrorS(err, "unable to get operator configuration", "namespace", operatorclient.OperatorNamespace, "kubedescheduler", operatorclient.OperatorConfigName)
+		klog.ErrorS(err, "unable to get operator configuration", "namespace", operatorNamespace, "kubedescheduler", operatorclient.OperatorConfigName)
 		return err
 	}
 
@@ -479,6 +481,7 @@ func (c *TargetConfigReconciler) manageSoftTainterClusterRole(descheduler *desch
 
 func (c *TargetConfigReconciler) manageSoftTainterClusterRoleBinding(descheduler *deschedulerv1.KubeDescheduler, stEnabled bool) (*rbacv1.ClusterRoleBinding, bool, error) {
 	required := resourceread.ReadClusterRoleBindingV1OrDie(bindata.MustAsset("assets/kube-descheduler/softtainterclusterrolebinding.yaml"))
+	setBindingSubjectsNamespace(required.Subjects, descheduler.Namespace)
 	ownerReference := metav1.OwnerReference{
 		APIVersion: "operator.openshift.io/v1",
 		Kind:       "KubeDescheduler",
@@ -497,6 +500,7 @@ func (c *TargetConfigReconciler) manageSoftTainterClusterRoleBinding(descheduler
 
 func (c *TargetConfigReconciler) manageClusterRoleBinding(descheduler *deschedulerv1.KubeDescheduler) (*rbacv1.ClusterRoleBinding, bool, error) {
 	required := resourceread.ReadClusterRoleBindingV1OrDie(bindata.MustAsset("assets/kube-descheduler/operandclusterrolebinding.yaml"))
+	setBindingSubjectsNamespace(required.Subjects, descheduler.Namespace)
 	ownerReference := metav1.OwnerReference{
 		APIVersion: "operator.openshift.io/v1",
 		Kind:       "KubeDescheduler",
@@ -513,6 +517,7 @@ func (c *TargetConfigReconciler) manageClusterRoleBinding(descheduler *deschedul
 
 func (c *TargetConfigReconciler) manageClusterMonitoringViewClusterRoleBinding(descheduler *deschedulerv1.KubeDescheduler) (*rbacv1.ClusterRoleBinding, bool, error) {
 	required := resourceread.ReadClusterRoleBindingV1OrDie(bindata.MustAsset("assets/kube-descheduler/operandclusterrolebindingprometheus.yaml"))
+	setBindingSubjectsNamespace(required.Subjects, descheduler.Namespace)
 	ownerReference := metav1.OwnerReference{
 		APIVersion: "operator.openshift.io/v1",
 		Kind:       "KubeDescheduler",
@@ -529,6 +534,7 @@ func (c *TargetConfigReconciler) manageClusterMonitoringViewClusterRoleBinding(d
 
 func (c *TargetConfigReconciler) managePrometheusRule(descheduler *deschedulerv1.KubeDescheduler) (*unstructured.Unstructured, bool, error) {
 	required := resourceread.ReadUnstructuredOrDie(bindata.MustAsset("assets/kube-descheduler/prometheusrule.yaml"))
+	required.SetNamespace(descheduler.Namespace)
 	ownerReference := metav1.OwnerReference{
 		APIVersion: "operator.openshift.io/v1",
 		Kind:       "KubeDescheduler",
@@ -542,6 +548,7 @@ func (c *TargetConfigReconciler) managePrometheusRule(descheduler *deschedulerv1
 
 func (c *TargetConfigReconciler) managePSIAlert(descheduler *deschedulerv1.KubeDescheduler, stEnabled bool) (*unstructured.Unstructured, bool, error) {
 	required := resourceread.ReadUnstructuredOrDie(bindata.MustAsset("assets/kube-descheduler/psialert.yaml"))
+	required.SetNamespace(descheduler.Namespace)
 	ownerReference := metav1.OwnerReference{
 		APIVersion: "operator.openshift.io/v1",
 		Kind:       "KubeDescheduler",
@@ -558,6 +565,13 @@ func (c *TargetConfigReconciler) managePSIAlert(descheduler *deschedulerv1.KubeD
 
 func (c *TargetConfigReconciler) manageSoftTainterValidatingAdmissionPolicy(descheduler *deschedulerv1.KubeDescheduler, stEnabled bool) (*admissionv1.ValidatingAdmissionPolicy, bool, error) {
 	required := resourceread.ReadValidatingAdmissionPolicyV1OrDie(bindata.MustAsset("assets/kube-descheduler/softtaintervalidatingadmissionpolicy.yaml"))
+	for i := range required.Spec.MatchConditions {
+		required.Spec.MatchConditions[i].Expression = strings.ReplaceAll(
+			required.Spec.MatchConditions[i].Expression,
+			operatorclient.OperatorNamespace,
+			descheduler.Namespace,
+		)
+	}
 	ownerReference := metav1.OwnerReference{
 		APIVersion: "operator.openshift.io/v1",
 		Kind:       "KubeDescheduler",
@@ -591,6 +605,7 @@ func (c *TargetConfigReconciler) manageSoftTainterValidatingAdmissionPolicyBindi
 
 func (c *TargetConfigReconciler) manageSoftTainterClusterMonitoringViewClusterRoleBinding(descheduler *deschedulerv1.KubeDescheduler, stEnabled bool) (*rbacv1.ClusterRoleBinding, bool, error) {
 	required := resourceread.ReadClusterRoleBindingV1OrDie(bindata.MustAsset("assets/kube-descheduler/softtainterclusterrolebindingprometheus.yaml"))
+	setBindingSubjectsNamespace(required.Subjects, descheduler.Namespace)
 	ownerReference := metav1.OwnerReference{
 		APIVersion: "operator.openshift.io/v1",
 		Kind:       "KubeDescheduler",
@@ -661,6 +676,7 @@ func (c *TargetConfigReconciler) manageOperandRole(descheduler *deschedulerv1.Ku
 func (c *TargetConfigReconciler) manageOperandRoleBinding(descheduler *deschedulerv1.KubeDescheduler) (*rbacv1.RoleBinding, bool, error) {
 	required := resourceread.ReadRoleBindingV1OrDie(bindata.MustAsset("assets/kube-descheduler/operandrolebinding.yaml"))
 	required.Namespace = descheduler.Namespace
+	setBindingSubjectsNamespace(required.Subjects, descheduler.Namespace)
 	ownerReference := metav1.OwnerReference{
 		APIVersion: "operator.openshift.io/v1",
 		Kind:       "KubeDescheduler",
@@ -698,6 +714,7 @@ func (c *TargetConfigReconciler) manageSoftTainterRole(descheduler *deschedulerv
 func (c *TargetConfigReconciler) manageSoftTainterRoleBinding(descheduler *deschedulerv1.KubeDescheduler, stEnabled bool) (*rbacv1.RoleBinding, bool, error) {
 	required := resourceread.ReadRoleBindingV1OrDie(bindata.MustAsset("assets/kube-descheduler/softtainterrolebinding.yaml"))
 	required.Namespace = descheduler.Namespace
+	setBindingSubjectsNamespace(required.Subjects, descheduler.Namespace)
 	ownerReference := metav1.OwnerReference{
 		APIVersion: "operator.openshift.io/v1",
 		Kind:       "KubeDescheduler",
@@ -771,8 +788,62 @@ func (c *TargetConfigReconciler) manageService(descheduler *deschedulerv1.KubeDe
 
 func (c *TargetConfigReconciler) manageServiceMonitor(descheduler *deschedulerv1.KubeDescheduler) (bool, error) {
 	required := resourceread.ReadUnstructuredOrDie(bindata.MustAsset("assets/kube-descheduler/servicemonitor.yaml"))
+	required.SetNamespace(descheduler.Namespace)
+
+	ownerReference := metav1.OwnerReference{
+		APIVersion: "operator.openshift.io/v1",
+		Kind:       "KubeDescheduler",
+		Name:       descheduler.Name,
+		UID:        descheduler.UID,
+	}
+	controller.EnsureOwnerRef(required, ownerReference)
+
+	if err := unstructured.SetNestedStringSlice(required.Object, []string{descheduler.Namespace}, "spec", "namespaceSelector", "matchNames"); err != nil {
+		return false, fmt.Errorf("failed to set ServiceMonitor namespaceSelector: %w", err)
+	}
+
+	// Bindata has a hardcoded namespace in serverName. SetNestedField cannot address
+	// slice indexes (spec.endpoints[0]), so update tlsConfig.serverName via NestedSlice.
+	serverName := fmt.Sprintf("metrics.%s.svc", descheduler.Namespace)
+	if err := setServiceMonitorServerName(required, serverName); err != nil {
+		return false, err
+	}
+
 	_, changed, err := resourceapply.ApplyKnownUnstructured(c.ctx, c.dynamicClient, c.eventRecorder, required)
 	return changed, err
+}
+
+func setServiceMonitorServerName(sm *unstructured.Unstructured, serverName string) error {
+	endpoints, found, err := unstructured.NestedSlice(sm.Object, "spec", "endpoints")
+	if err != nil {
+		return fmt.Errorf("failed to read ServiceMonitor endpoints: %w", err)
+	}
+	if !found || len(endpoints) == 0 {
+		return fmt.Errorf("ServiceMonitor spec.endpoints is empty")
+	}
+	ep, ok := endpoints[0].(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("ServiceMonitor spec.endpoints[0] is not an object")
+	}
+	tlsConfig, ok := ep["tlsConfig"].(map[string]interface{})
+	if !ok || tlsConfig == nil {
+		return fmt.Errorf("ServiceMonitor spec.endpoints[0].tlsConfig is missing or not an object")
+	}
+	tlsConfig["serverName"] = serverName
+	ep["tlsConfig"] = tlsConfig
+	endpoints[0] = ep
+	if err := unstructured.SetNestedSlice(sm.Object, endpoints, "spec", "endpoints"); err != nil {
+		return fmt.Errorf("failed to set ServiceMonitor serverName %q: %w", serverName, err)
+	}
+	return nil
+}
+
+func setBindingSubjectsNamespace(subjects []rbacv1.Subject, namespace string) {
+	for i := range subjects {
+		if subjects[i].Namespace == operatorclient.OperatorNamespace {
+			subjects[i].Namespace = namespace
+		}
+	}
 }
 
 func (c *TargetConfigReconciler) manageConfigMap(descheduler *deschedulerv1.KubeDescheduler) (*v1.ConfigMap, bool, error) {
@@ -1098,6 +1169,18 @@ func (c *TargetConfigReconciler) manageSoftTainterDeployment(descheduler *desche
 	required := resourceread.ReadDeploymentV1OrDie(bindata.MustAsset("assets/kube-descheduler/softtainterdeployment.yaml"))
 	required.Name = operatorclient.SoftTainterOperandName
 	required.Namespace = descheduler.Namespace
+	if len(required.Spec.Template.Spec.Containers) > 0 {
+		required.Spec.Template.Spec.Containers[0].Env = append(required.Spec.Template.Spec.Containers[0].Env,
+			v1.EnvVar{
+				Name: "OPERATOR_POD_NAMESPACE",
+				ValueFrom: &v1.EnvVarSource{
+					FieldRef: &v1.ObjectFieldSelector{
+						FieldPath: "metadata.namespace",
+					},
+				},
+			},
+		)
+	}
 	if stEnabled {
 		return c.manageDeployment(required, descheduler, targetImageKey, c.softtainterImagePullSpec, specAnnotations)
 	}
@@ -1152,13 +1235,14 @@ func (c *TargetConfigReconciler) eventHandler() cache.ResourceEventHandler {
 }
 
 func (c *TargetConfigReconciler) checkNamespaceMonitoringLabel() error {
-	operatorNamespace, err := c.namespaceLister.Get(operatorclient.OperatorNamespace)
+	nsName := c.deschedulerClient.GetNamespace()
+	operatorNamespace, err := c.namespaceLister.Get(nsName)
 	if err != nil {
 		klog.ErrorS(err, "error fetching operator namespace")
 		return err
 	}
 	if operatorNamespace.GetLabels()[operatorclient.OpenshiftClusterMonitoringLabelKey] != operatorclient.OpenshiftClusterMonitoringLabelValue {
-		return fmt.Errorf("namespace %v is not labeled with %v=%v", operatorclient.OperatorNamespace, operatorclient.OpenshiftClusterMonitoringLabelKey, operatorclient.OpenshiftClusterMonitoringLabelValue)
+		return fmt.Errorf("namespace %v is not labeled with %v=%v", nsName, operatorclient.OpenshiftClusterMonitoringLabelKey, operatorclient.OpenshiftClusterMonitoringLabelValue)
 	}
 	return nil
 }

--- a/pkg/operator/target_config_reconciler_test.go
+++ b/pkg/operator/target_config_reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -100,6 +101,7 @@ func initTargetConfigReconciler(ctx context.Context, kubeClientObjects, configOb
 	operatorConfigInformers := operatorclientinformers.NewSharedInformerFactory(operatorConfigClient, 10*time.Minute)
 	deschedulerClient := &operatorclient.DeschedulerClient{
 		Ctx:            ctx,
+		Namespace:      operatorclient.OperatorNamespace,
 		SharedInformer: operatorConfigInformers.Kubedeschedulers().V1().KubeDeschedulers().Informer(),
 		OperatorClient: operatorConfigClient.KubedeschedulersV1(),
 	}
@@ -574,7 +576,7 @@ func TestManageSoftTainterDeployment(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "softtainter",
 			Namespace:       "openshift-kube-descheduler-operator",
-			Annotations:     map[string]string{"operator.openshift.io/spec-hash": "ef97d3d0f3b5175d75facaefb8102ae00469a9d38676a3b6b4a96ef67b52b1b5"},
+			Annotations:     map[string]string{"operator.openshift.io/spec-hash": "dbc8d6adc396d87de0c49f7c57ac381d417cd96919167c85f6e22d21dfd24f3c"},
 			Labels:          map[string]string{"app": "softtainer"},
 			OwnerReferences: []metav1.OwnerReference{{APIVersion: "operator.openshift.io/v1", Kind: "KubeDescheduler", Name: "cluster"}},
 		},
@@ -615,6 +617,16 @@ func TestManageSoftTainterDeployment(t *testing.T) {
 								InitialDelaySeconds: 5,
 								PeriodSeconds:       5,
 								FailureThreshold:    1,
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name: "OPERATOR_POD_NAMESPACE",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "metadata.namespace",
+										},
+									},
+								},
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
@@ -1295,6 +1307,7 @@ func setupFakeClientsWithConfigObserver(t *testing.T, apiServer *configv1.APISer
 
 	deschedulerClient := &operatorclient.DeschedulerClient{
 		Ctx:            ctx,
+		Namespace:      operatorclient.OperatorNamespace,
 		SharedInformer: operatorConfigInformers.Kubedeschedulers().V1().KubeDeschedulers().Informer(),
 		OperatorClient: operatorConfigClient.KubedeschedulersV1(),
 	}
@@ -1332,6 +1345,7 @@ func setupFakeClientsWithConfigObserver(t *testing.T, apiServer *configv1.APISer
 		configInformers,
 		resourceSyncController,
 		eventRecorder,
+		operatorclient.OperatorNamespace,
 	)
 
 	// Create target config reconciler - this registers event handlers with informers
@@ -1674,5 +1688,53 @@ func TestCheckProfileConflicts(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestSetServiceMonitorServerName(t *testing.T) {
+	sm := &unstructured.Unstructured{Object: map[string]interface{}{
+		"spec": map[string]interface{}{
+			"endpoints": []interface{}{
+				map[string]interface{}{
+					"tlsConfig": map[string]interface{}{
+						"caFile":     "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt",
+						"serverName": "metrics.openshift-kube-descheduler-operator.svc",
+					},
+				},
+			},
+		},
+	}}
+
+	want := "metrics.custom-ns.svc"
+	if err := setServiceMonitorServerName(sm, want); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	endpoints, found, err := unstructured.NestedSlice(sm.Object, "spec", "endpoints")
+	if err != nil || !found || len(endpoints) == 0 {
+		t.Fatalf("failed to read endpoints: found=%v err=%v", found, err)
+	}
+	ep, ok := endpoints[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("endpoints[0] is not an object")
+	}
+	tlsConfig, ok := ep["tlsConfig"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("tlsConfig is not an object")
+	}
+	got, ok := tlsConfig["serverName"].(string)
+	if !ok || got != want {
+		t.Fatalf("serverName = %q, want %q", got, want)
+	}
+
+	missingTLS := &unstructured.Unstructured{Object: map[string]interface{}{
+		"spec": map[string]interface{}{
+			"endpoints": []interface{}{
+				map[string]interface{}{},
+			},
+		},
+	}}
+	if err := setServiceMonitorServerName(missingTLS, want); err == nil {
+		t.Fatal("expected error when tlsConfig is missing")
 	}
 }

--- a/pkg/operator/target_config_reconciler_test.go
+++ b/pkg/operator/target_config_reconciler_test.go
@@ -1738,3 +1738,62 @@ func TestSetServiceMonitorServerName(t *testing.T) {
 		t.Fatal("expected error when tlsConfig is missing")
 	}
 }
+
+func TestManageServiceMonitorCustomNamespace(t *testing.T) {
+	const customNS = "custom-ns"
+	ctx := context.Background()
+	gvr := schema.GroupVersionResource{Group: "monitoring.coreos.com", Version: "v1", Resource: "servicemonitors"}
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "ServiceMonitorList"},
+	)
+	c := &TargetConfigReconciler{
+		ctx:           ctx,
+		dynamicClient: dynamicClient,
+		eventRecorder: NewFakeRecorder(1024),
+	}
+	descheduler := &deschedulerv1.KubeDescheduler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      operatorclient.OperatorConfigName,
+			Namespace: customNS,
+			UID:       "test-uid",
+		},
+	}
+
+	if _, err := c.manageServiceMonitor(descheduler); err != nil {
+		t.Fatalf("manageServiceMonitor: %v", err)
+	}
+
+	got, err := dynamicClient.Resource(gvr).Namespace(customNS).Get(ctx, "kube-descheduler", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get ServiceMonitor: %v", err)
+	}
+	if got.GetNamespace() != customNS {
+		t.Fatalf("metadata.namespace = %q, want %q", got.GetNamespace(), customNS)
+	}
+
+	matchNames, found, err := unstructured.NestedStringSlice(got.Object, "spec", "namespaceSelector", "matchNames")
+	if err != nil || !found {
+		t.Fatalf("namespaceSelector.matchNames not found: found=%v err=%v", found, err)
+	}
+	if len(matchNames) != 1 || matchNames[0] != customNS {
+		t.Fatalf("namespaceSelector.matchNames = %v, want [%s]", matchNames, customNS)
+	}
+
+	endpoints, found, err := unstructured.NestedSlice(got.Object, "spec", "endpoints")
+	if err != nil || !found || len(endpoints) == 0 {
+		t.Fatalf("failed to read endpoints: found=%v err=%v", found, err)
+	}
+	ep, ok := endpoints[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("endpoints[0] is not an object")
+	}
+	tlsConfig, ok := ep["tlsConfig"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("tlsConfig is not an object")
+	}
+	serverName, ok := tlsConfig["serverName"].(string)
+	if !ok || serverName != "metrics.custom-ns.svc" {
+		t.Fatalf("tlsConfig.serverName = %q, want %q", serverName, "metrics.custom-ns.svc")
+	}
+}

--- a/pkg/operator/target_config_reconciler_test.go
+++ b/pkg/operator/target_config_reconciler_test.go
@@ -576,7 +576,7 @@ func TestManageSoftTainterDeployment(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "softtainter",
 			Namespace:       "openshift-kube-descheduler-operator",
-			Annotations:     map[string]string{"operator.openshift.io/spec-hash": "dbc8d6adc396d87de0c49f7c57ac381d417cd96919167c85f6e22d21dfd24f3c"},
+			Annotations:     map[string]string{"operator.openshift.io/spec-hash": "ef97d3d0f3b5175d75facaefb8102ae00469a9d38676a3b6b4a96ef67b52b1b5"},
 			Labels:          map[string]string{"app": "softtainer"},
 			OwnerReferences: []metav1.OwnerReference{{APIVersion: "operator.openshift.io/v1", Kind: "KubeDescheduler", Name: "cluster"}},
 		},
@@ -617,16 +617,6 @@ func TestManageSoftTainterDeployment(t *testing.T) {
 								InitialDelaySeconds: 5,
 								PeriodSeconds:       5,
 								FailureThreshold:    1,
-							},
-							Env: []corev1.EnvVar{
-								{
-									Name: "OPERATOR_POD_NAMESPACE",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "metadata.namespace",
-										},
-									},
-								},
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{

--- a/pkg/softtainter/softtainter.go
+++ b/pkg/softtainter/softtainter.go
@@ -69,6 +69,7 @@ type softTainter struct {
 	client                            client.Client
 	resyncPeriod                      time.Duration
 	policyConfigFile                  string
+	namespace                         string
 	nodeUtilizationFactory            func(promapi.Client, string) NodeUtilization
 }
 
@@ -99,7 +100,7 @@ func (st *softTainter) Reconcile(ctx context.Context, request reconcile.Request)
 	}
 
 	err = st.client.Get(ctx, client.ObjectKey{
-		Namespace: operatorclient.OperatorNamespace,
+		Namespace: st.namespace,
 		Name:      operatorclient.OperatorConfigName,
 	}, &des)
 	if err != nil {
@@ -558,10 +559,10 @@ func TickLimitedControllerRateLimiter[T comparable](tickLimit time.Duration) wor
 }
 
 // RegisterReconciler creates a new Reconciler and registers it into manager.
-func RegisterReconciler(mgr manager.Manager, policyConfigFile string) error {
+func RegisterReconciler(mgr manager.Manager, policyConfigFile string, namespace string) error {
 	des := desv1.KubeDescheduler{}
 	err := mgr.GetAPIReader().Get(context.Background(), client.ObjectKey{
-		Namespace: operatorclient.OperatorNamespace,
+		Namespace: namespace,
 		Name:      operatorclient.OperatorConfigName,
 	}, &des)
 	if err != nil {
@@ -584,6 +585,7 @@ func RegisterReconciler(mgr manager.Manager, policyConfigFile string) error {
 				client:                 mgr.GetClient(),
 				resyncPeriod:           resyncPeriod,
 				policyConfigFile:       policyConfigFile,
+				namespace:              namespace,
 				nodeUtilizationFactory: newNodeUtilizationFactory,
 			},
 		},

--- a/pkg/softtainter/softtainter_test.go
+++ b/pkg/softtainter/softtainter_test.go
@@ -432,6 +432,7 @@ func TestReconcile(t *testing.T) {
 				client:                 cl,
 				resyncPeriod:           60 * time.Second,
 				policyConfigFile:       path.Join(getTestFilesLocation(t), tc.testfilename),
+				namespace:              operatorclient.OperatorNamespace,
 				nodeUtilizationFactory: tc.nodeUtilization.newNodeUtilizationFactory,
 			}
 			result, err := st.Reconcile(ctx, reconcile.Request{})


### PR DESCRIPTION
Hi Team,

PTAL, Summary:
When the operator is deployed via OLM in a namespace other than the default openshift-kube-descheduler-operator (e.g., test-kube-descheduler-operator), two issues prevent operand pods from coming up:
1. The operator hardcodes the namespace throughout the codebase, causing informer RBAC failures, CR lookup failures, and incorrect RBAC binding subjects.
2. The ServiceMonitor hardcodes serverName in tlsConfig, causing TLS certificate validation failures when the serving cert SAN doesn't match the hardcoded namespace.

Fix 1: Dynamic namespace support
```
The operator hardcodes openshift-kube-descheduler-operator as the operator namespace, causing three cascading failures when deployed in a different namespace:
- Informer RBAC failures: Informers for ConfigMaps and Secrets try to watch in the hardcoded namespace, where the ServiceAccount has no permissions.
- CR not found: DeschedulerClient looks for the KubeDescheduler CR in the wrong namespace.
- Incorrect RBAC subjects: ClusterRoleBindings and RoleBindings reference ServiceAccounts in the hardcoded namespace, so the operand SA has no permissions.
```
Fix 2: ServiceMonitor TLS serverName
```
The ServiceMonitor hardcodes serverName: metrics.openshift-kube-descheduler-operator.svc in tlsConfig. When deployed in a different namespace, the serving cert SAN is metrics.<actual-namespace>.svc, causing TLS validation to fail and Prometheus scraping to break.
```

// Executions:
// Verification with Own Namespace
```
oc get csv -n openshift-kube-descheduler-operator
NAME                                    DISPLAY                     VERSION   RELEASE   REPLACES   PHASE
clusterkubedescheduleroperator.v5.4.3   Kube Descheduler Operator   5.4.3                          Succeeded

oc get operatorgroup,subscription -n openshift-kube-descheduler-operator
NAME                                                 AGE
operatorgroup.operators.coreos.com/operator-sdk-og   103s

NAME                                                                          PACKAGE                             SOURCE                                      CHANNEL
subscription.operators.coreos.com/clusterkubedescheduleroperator-v5-4-3-sub   cluster-kube-descheduler-operator   cluster-kube-descheduler-operator-catalog   operator-sdk-run-bundle

oc get pods -n openshift-kube-descheduler-operator -o wide
NAME                                                              READY   STATUS      RESTARTS   AGE   IP            NODE                                        NOMINATED NODE   READINESS GATES
439762bb68e73df69fe3d1110282e43722a87ac1a3a621d706b7a10188j8tfw   0/1     Completed   0          57s   10.129.2.42   ip-10-0-52-93.us-east-2.compute.internal    <none>           <none>
descheduler-8549d6c787-9ncxf                                      1/1     Running     0          4s    10.128.2.27   ip-10-0-18-163.us-east-2.compute.internal   <none>           <none>
descheduler-operator-8486c9b984-c2d59                             1/1     Running     0          49s   10.128.2.26   ip-10-0-18-163.us-east-2.compute.internal   <none>           <none>
support-ropatil-cluster-kube-descheduler-operator-bundle-test97   1/1     Running     0          62s   10.129.2.41   ip-10-0-52-93.us-east-2.compute.internal    <none>           <none>

// Check what certificate was issued/Verify TLS cert hostname matches
oc get secret descheduler-operator-serving-cert -n openshift-kube-descheduler-operator \
  -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -noout -text | grep DNS
DNS:descheduler-operator-metrics.openshift-kube-descheduler-operator.svc, DNS:descheduler-operator-metrics.openshift-kube-descheduler-operator.svc.cluster.local

// Verify the TLS certificate is valid by curling the service directly:
oc exec deployment/descheduler-operator -n openshift-kube-descheduler-operator -- \
  curl -v -k https://descheduler-operator-metrics.openshift-kube-descheduler-operator.svc:8443/healthz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 172.30.64.35:8443...
* Connected to descheduler-operator-metrics.openshift-kube-descheduler-operator.svc (172.30.64.35) port 8443 (#0)

> Host: descheduler-operator-metrics.openshift-kube-descheduler-operator.svc:8443
> User-Agent: curl/7.76.1
> Accept: */*


// Verify the TLS certificate is valid by curling the service directl with invalid port 
oc exec deployment/descheduler-operator -n openshift-kube-descheduler-operator --   curl -v -k https://descheduler-operator-metrics.openshift-kube-descheduler-operator.svc:9443/healthz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 172.30.64.35:9443...
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0^C
```

// Verification with Single Namespace
```
oc get pods -n test-kube-descheduler-operator -o wide
NAME                                                              READY   STATUS      RESTARTS   AGE   IP            NODE                                        NOMINATED NODE   READINESS GATES
439762bb68e73df69fe3d1110282e43722a87ac1a3a621d706b7a101888bfcq   0/1     Completed   0          69s   10.129.2.39   ip-10-0-52-93.us-east-2.compute.internal    <none>           <none>
descheduler-799977686f-gt7km                                      1/1     Running     0          8s    10.128.2.25   ip-10-0-18-163.us-east-2.compute.internal   <none>           <none>
descheduler-operator-7865868f68-96q87                             1/1     Running     0          60s   10.128.2.24   ip-10-0-18-163.us-east-2.compute.internal   <none>           <none>
support-ropatil-cluster-kube-descheduler-operator-bundle-test97   1/1     Running     0          74s   10.129.2.38   ip-10-0-52-93.us-east-2.compute.internal    <none>           <none>

// Check what certificate was issued/Verify TLS cert hostname matches
oc get secret descheduler-operator-serving-cert -n test-kube-descheduler-operator \
  -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -noout -text | grep DNS
DNS:descheduler-operator-metrics.test-kube-descheduler-operator.svc, DNS:descheduler-operator-metrics.test-kube-descheduler-operator.svc.cluster.local

// Verify the TLS certificate is valid by curling the service directly:
oc exec deployment/descheduler-operator -n test-kube-descheduler-operator -- \
  curl -v -k https://descheduler-operator-metrics.test-kube-descheduler-operator.svc:8443/healthz
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 172.30.126.217:8443...
* Connected to descheduler-operator-metrics.test-kube-descheduler-operator.svc (172.30.126.217) port 8443 (#0)
* ALPN, offering h2
* 

// Verify the TLS certificate is valid by curling the service directl with invalid port 
oc exec deployment/descheduler-operator -n test-kube-descheduler-operator --   curl -v -k https://descheduler-operator-metrics.test-kube-descheduler-operator.svc:9443/healthz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 172.30.192.116:9443...
  0     0    0     0    0     0      0      0 --:--:--  0:00:15 --:--:--     0^C
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized operator namespace handling across configuration, reconciliation, permissions, and SoftTainter resources.
  - Monitoring endpoints now discover service addresses dynamically, improving support for custom deployment namespaces.
  - ServiceMonitor TLS settings are updated to match the monitored service and namespace.
  - Improved validation and error handling for incomplete ServiceMonitor TLS configuration.
  - Updated resource reconciliation and monitoring behavior for deployments outside the default namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->