### PR TITLE
OCPBUGS-122248: Soft Tainter operand pod scaled down 

### DIFF
--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -1200,6 +1200,20 @@ func hasKubeVirtRelieveAndMigrateProfile(profiles []deschedulerv1.DeschedulerPro
 
 func (c *TargetConfigReconciler) isSoftTainterNeeded(descheduler *deschedulerv1.KubeDescheduler) (bool, error) {
 	if hasKubeVirtRelieveAndMigrateProfile(descheduler.Spec.Profiles) {
+		kvDeployed, err := c.isKubeVirtDeployed()
+		if err != nil {
+			return false, err
+		}
+		if !kvDeployed {
+			return false, nil
+		}
+		psiEnabled, err := c.isPSIenabled()
+		if err != nil {
+			return false, err
+		}
+		if !psiEnabled {
+			return false, nil
+		}
 		return true, nil
 	}
 

--- a/pkg/operator/target_config_reconciler_test.go
+++ b/pkg/operator/target_config_reconciler_test.go
@@ -669,6 +669,8 @@ func TestManageSoftTainterDeployment(t *testing.T) {
 		objects                []runtime.Object
 		checkContainerOnly     bool
 		checkContainerArgsOnly bool
+		psiAvailable           bool
+		expectEnabled          bool
 	}{
 		{
 			name: "DevKubeVirtRelieveAndMigrate",
@@ -680,9 +682,53 @@ func TestManageSoftTainterDeployment(t *testing.T) {
 				}
 				spec.DeschedulingIntervalSeconds = utilptr.To[int32](10)
 			}),
+			objects: []runtime.Object{
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "node1",
+						Labels: map[string]string{"kubevirt.io/schedulable": "true"},
+					},
+				},
+			},
 			checkContainerOnly:     false,
 			checkContainerArgsOnly: false,
+			psiAvailable:           true,
+			expectEnabled:          true,
 			want:                   expectedSoftTainterDeployment,
+		},
+		{
+			name: "DevKubeVirtRelieveAndMigrate without PSI",
+			descheduler: buildKubeDeschedulerSpec(func(spec *deschedulerv1.KubeDeschedulerSpec) {
+				spec.Profiles = []deschedulerv1.DeschedulerProfile{deschedulerv1.DevKubeVirtRelieveAndMigrate}
+				spec.ProfileCustomizations = &deschedulerv1.ProfileCustomizations{
+					DevDeviationThresholds:      &deschedulerv1.LowDeviationThreshold,
+					DevActualUtilizationProfile: deschedulerv1.PrometheusCPUCombinedProfile,
+				}
+				spec.DeschedulingIntervalSeconds = utilptr.To[int32](10)
+			}),
+			objects: []runtime.Object{
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "node1",
+						Labels: map[string]string{"kubevirt.io/schedulable": "true"},
+					},
+				},
+			},
+			psiAvailable:  false,
+			expectEnabled: false,
+		},
+		{
+			name: "DevKubeVirtRelieveAndMigrate without KubeVirt",
+			descheduler: buildKubeDeschedulerSpec(func(spec *deschedulerv1.KubeDeschedulerSpec) {
+				spec.Profiles = []deschedulerv1.DeschedulerProfile{deschedulerv1.DevKubeVirtRelieveAndMigrate}
+				spec.ProfileCustomizations = &deschedulerv1.ProfileCustomizations{
+					DevDeviationThresholds:      &deschedulerv1.LowDeviationThreshold,
+					DevActualUtilizationProfile: deschedulerv1.PrometheusCPUCombinedProfile,
+				}
+				spec.DeschedulingIntervalSeconds = utilptr.To[int32](10)
+			}),
+			psiAvailable:  true,
+			expectEnabled: false,
 		},
 		{
 			name: "LifecycleAndUtilization (without the softtainer) and no leftovers on existing nodes",
@@ -765,6 +811,7 @@ func TestManageSoftTainterDeployment(t *testing.T) {
 			},
 			checkContainerOnly:     false,
 			checkContainerArgsOnly: false,
+			expectEnabled:          true,
 			want:                   expectedSoftTainterDeployment,
 		},
 		{
@@ -815,6 +862,7 @@ func TestManageSoftTainterDeployment(t *testing.T) {
 			},
 			checkContainerOnly:     false,
 			checkContainerArgsOnly: false,
+			expectEnabled:          true,
 			want:                   expectedSoftTainterDeployment,
 		},
 	}
@@ -826,10 +874,21 @@ func TestManageSoftTainterDeployment(t *testing.T) {
 			}
 
 			targetConfigReconciler, _ := initTargetConfigReconciler(ctx, tt.objects, nil, nil, nil)
+			if tt.psiAvailable {
+				targetConfigReconciler.psiPath = tempPSIPath
+			} else {
+				targetConfigReconciler.psiPath = path.Join(tempPSIPath, "MISSING")
+			}
 
 			enabled, err := targetConfigReconciler.isSoftTainterNeeded(tt.descheduler)
 			if err != nil {
 				t.Fatalf("Unexpected error: %v\n", err)
+			}
+			if enabled != tt.expectEnabled {
+				t.Fatalf("Expected isSoftTainterNeeded to return %v, got %v", tt.expectEnabled, enabled)
+			}
+			if tt.want == nil {
+				return
 			}
 			got, _, err := targetConfigReconciler.manageSoftTainterDeployment(tt.descheduler, nil, enabled)
 			if err != nil {


### PR DESCRIPTION
Hi Team,

PTAL on the PR. 

PR fix:  In isSoftTainterNeeded(), when the KubeVirt profile is configured, now checks both isKubeVirtDeployed() and isPSIenabled() before returning true. If either check fails, returns false — the soft tainter won't be deployed. The leftover taint cleanup path (lines 1220-1244) remains untouched, so the soft tainter will still be deployed to clean up stale taints when needed

Test updates (pkg/operator/target_config_reconciler_test.go):
```
- Added psiAvailable and expectEnabled fields to the test struct
- Existing DevKubeVirtRelieveAndMigrate test case now includes a KubeVirt-labeled node and psiAvailable: true
- Added two new test cases:
  - DevKubeVirtRelieveAndMigrate without PSI — verifies soft tainter is NOT deployed when PSI is unavailable
  - DevKubeVirtRelieveAndMigrate without KubeVirt — verifies soft tainter is NOT deployed when KubeVirt nodes are absent
- Updated the test loop to set psiPath based on psiAvailable and assert on expectEnabled
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Soft-tainer activation for KubeVirt relieve-and-migrate profiles now requires both KubeVirt deployment and PSI metrics to be available.
  * Soft-tainer deployment remains disabled when either prerequisite is unavailable.
  * Errors encountered while checking these prerequisites are now surfaced.

* **Tests**
  * Added coverage for available and unavailable PSI metrics and KubeVirt deployment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->